### PR TITLE
Fix/exit code sync

### DIFF
--- a/internal/condenser/monitor/monitor.go
+++ b/internal/condenser/monitor/monitor.go
@@ -2,7 +2,10 @@ package monitor
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
+	"os"
 	"path/filepath"
 	"raind/internal/condenser/store/csm"
 	"raind/internal/condenser/store/psm"
@@ -61,25 +64,7 @@ func (m *ContainerMonitor) Start() error {
 			procExist, _ := m.pidAlive(container.Pid)
 			// if process is not exist, change state to stopped
 			if !procExist {
-				log.Printf("[*] Container: %s down detected.", container.ContainerId)
-				if err := m.csmHandler.UpdateContainer(
-					container.ContainerId,
-					"stopped",
-					0,
-				); err != nil {
-					continue
-				}
-				if container.PodId != "" && !strings.HasPrefix(container.ContainerName, utils.PodInfraContainerNamePrefix) {
-					_ = m.psmHandler.UpdatePod(container.PodId, "degraded")
-				}
-				if err := m.csmHandler.UpdateExitStatus(
-					container.ContainerId,
-					-1,
-					"Error",
-					"process down detected.",
-				); err != nil {
-					continue
-				}
+				m.handleProcessDown(container)
 				continue
 			}
 
@@ -101,6 +86,109 @@ func (m *ContainerMonitor) Start() error {
 		}
 	}
 	return nil
+}
+
+const processDownDetectedMessage = "process down detected."
+
+func (m *ContainerMonitor) handleProcessDown(container ContainerMeta) {
+	if current, err := m.csmHandler.GetContainerById(container.ContainerId); err == nil && isFinalExitStatusKnown(current) {
+		return
+	}
+
+	log.Printf("[*] Container: %s down detected.", container.ContainerId)
+	if err := m.csmHandler.UpdateContainer(
+		container.ContainerId,
+		"stopped",
+		0,
+	); err != nil {
+		return
+	}
+	if container.PodId != "" && !strings.HasPrefix(container.ContainerName, utils.PodInfraContainerNamePrefix) {
+		_ = m.psmHandler.UpdatePod(container.PodId, "degraded")
+	}
+
+	if exitStatus, ok := m.resolveRuntimeExitStatusWithRetry(container.ContainerId, 2*time.Second, 50*time.Millisecond); ok {
+		if err := m.csmHandler.UpdateExitStatus(
+			container.ContainerId,
+			exitStatus.ExitCode,
+			exitStatus.Reason,
+			exitStatus.Message,
+		); err != nil {
+			return
+		}
+		return
+	}
+
+	if current, err := m.csmHandler.GetContainerById(container.ContainerId); err == nil && isFinalExitStatusKnown(current) {
+		return
+	}
+
+	_ = m.csmHandler.UpdateExitStatus(
+		container.ContainerId,
+		-1,
+		"Error",
+		processDownDetectedMessage,
+	)
+}
+
+type runtimeExitStatus struct {
+	Status   string `json:"status"`
+	ExitCode int    `json:"exit_code"`
+	Reason   string `json:"reason"`
+	Message  string `json:"message"`
+}
+
+func (m *ContainerMonitor) resolveRuntimeExitStatusWithRetry(containerId string, timeout time.Duration, interval time.Duration) (runtimeExitStatus, bool) {
+	deadline := time.Now().Add(timeout)
+	for {
+		if exitStatus, ok := readRuntimeExitStatus(containerId); ok {
+			return exitStatus, true
+		}
+		if !time.Now().Before(deadline) {
+			return runtimeExitStatus{}, false
+		}
+		time.Sleep(interval)
+	}
+}
+
+func readRuntimeExitStatus(containerId string) (runtimeExitStatus, bool) {
+	statePath := filepath.Join(utils.ContainerRootDir, containerId, "state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return runtimeExitStatus{}, false
+	}
+
+	var exitStatus runtimeExitStatus
+	if err := json.Unmarshal(data, &exitStatus); err != nil {
+		return runtimeExitStatus{}, false
+	}
+	if exitStatus.Status != "stopped" {
+		return runtimeExitStatus{}, false
+	}
+
+	exitStatus.Reason, exitStatus.Message = normalizeRuntimeExitStatus(exitStatus.ExitCode, exitStatus.Reason, exitStatus.Message)
+	return exitStatus, true
+}
+
+func normalizeRuntimeExitStatus(exitCode int, reason string, message string) (string, string) {
+	if reason == "" {
+		if exitCode == 0 {
+			reason = "Completed"
+		} else {
+			reason = "Error"
+		}
+	}
+	if message == "" {
+		message = fmt.Sprintf("exit code: %d", exitCode)
+	}
+	return reason, message
+}
+
+func isFinalExitStatusKnown(container csm.ContainerInfo) bool {
+	if container.State != "stopped" {
+		return false
+	}
+	return !(container.ExitCode == -1 && container.Message == processDownDetectedMessage)
 }
 
 func buildMetricsRecord(container ContainerMeta, prev CgroupCPUUsageSample) (MetricsRecord, CgroupCPUUsageSample, error) {

--- a/internal/droplet/command/shim.go
+++ b/internal/droplet/command/shim.go
@@ -10,9 +10,15 @@ func commandShim() *cli.Command {
 	return &cli.Command{
 		Name:      "shim",
 		Usage:     "shim process",
-		ArgsUsage: "<container-id> <fifo-path> <entrypoint>",
+		ArgsUsage: "[--tty] <container-id> <fifo-path> <entrypoint>",
 		Hidden:    true,
-		Action:    runShim,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:  "tty",
+				Usage: "enable TTY attach proxy",
+			},
+		},
+		Action: runShim,
 	}
 }
 
@@ -24,7 +30,12 @@ func runShim(ctx *cli.Context) error {
 	entrypoint := args[2:]
 
 	containerShim := container.NewContainerShim()
-	err := containerShim.Execute(containerId, fifo, entrypoint)
+	err := containerShim.Execute(container.ShimExecuteOption{
+		ContainerId: containerId,
+		Fifo:        fifo,
+		Entrypoint:  entrypoint,
+		Tty:         ctx.Bool("tty"),
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/droplet/container/create.go
+++ b/internal/droplet/container/create.go
@@ -172,41 +172,35 @@ func (c *ContainerCreator) Create(opt CreateOption) (err error) {
 		}
 	}
 
-	// 5. execute init subcommand
+	// 5. execute shim/supervisor subcommand.
+	//
+	// The shim is now used for both TTY and non-TTY containers so that it can
+	// wait for the container init process and persist the final exit status.
+	// TTY handling remains optional inside the shim.
 	var (
 		initPid int
 		shimPid int
 	)
-	if opt.TtyFlag {
-		// cleanup old files before execute shim
-		stage = "cleanup_shim_file"
-		err = c.cleanupShimFile(opt.ContainerId)
-		if err != nil {
-			return err
-		}
-
-		stage = "execute_shim"
-		pid, err = c.processExecutor.executeShim(opt.ContainerId, spec, fifo)
-		if err != nil {
-			return err
-		}
-		shimPid = pid
-
-		// wait for pidfile from shim
-		stage = "wait_init_pid"
-		initPid, err = c.waitInitPid(opt.ContainerId, 3*time.Second, 20*time.Millisecond)
-		if err != nil {
-			return err
-		}
-		pid = initPid
-	} else {
-		stage = "execute_init"
-		pid, err = c.processExecutor.executeInit(opt.ContainerId, spec, fifo)
-		if err != nil {
-			return err
-		}
-		initPid = pid
+	stage = "cleanup_shim_file"
+	err = c.cleanupShimFile(opt.ContainerId)
+	if err != nil {
+		return err
 	}
+
+	stage = "execute_shim"
+	pid, err = c.processExecutor.executeShim(opt.ContainerId, spec, fifo, opt.TtyFlag)
+	if err != nil {
+		return err
+	}
+	shimPid = pid
+
+	// wait for pidfile from shim
+	stage = "wait_init_pid"
+	initPid, err = c.waitInitPid(opt.ContainerId, 3*time.Second, 20*time.Millisecond)
+	if err != nil {
+		return err
+	}
+	pid = initPid
 
 	// 6. cgroup setup
 	stage = "setup_cgroup"
@@ -306,8 +300,7 @@ func (c *ContainerCreator) specSecureLoad(containerId string) (spec.Spec, error)
 // It is an interface so that the behavior can be mocked in tests and
 // replaced by alternative implementations if needed.
 type processExecutor interface {
-	executeInit(containerId string, spec spec.Spec, fifo string) (int, error)
-	executeShim(containerId string, spec spec.Spec, fifo string) (int, error)
+	executeShim(containerId string, spec spec.Spec, fifo string, tty bool) (int, error)
 }
 
 // containerInitExecutor is the default implementation of processExecutor.
@@ -366,15 +359,20 @@ func prepareRootlessInitLog(path string, rootlessConfig spec.RootlessConfigObjec
 	return os.Chown(path, uid, gid)
 }
 
-func (c *containerInitExecutor) executeShim(containerId string, spec spec.Spec, fifo string) (int, error) {
+func (c *containerInitExecutor) executeShim(containerId string, spec spec.Spec, fifo string, tty bool) (int, error) {
 	// retrieve entrypoint from spec
 	entrypoint := spec.Process.Args
 
 	// prepare shim subcommand
-	shimArgs := append([]string{"shim", containerId, fifo}, entrypoint...)
+	shimArgs := []string{"shim"}
+	if tty {
+		shimArgs = append(shimArgs, "--tty")
+	}
+	shimArgs = append(shimArgs, containerId, fifo)
+	shimArgs = append(shimArgs, entrypoint...)
 	cmd := c.commandFactory.Command(utils.SelfBinPath(), shimArgs...)
 
-	// execute init subcommand
+	// execute shim subcommand
 	if err := cmd.Start(); err != nil {
 		return -1, err
 	}

--- a/internal/droplet/container/create_test.go
+++ b/internal/droplet/container/create_test.go
@@ -41,6 +41,7 @@ type createProcessCall struct {
 	containerId string
 	fifo        string
 	entrypoint  []string
+	tty         bool
 }
 
 func (f *fakeCreateProcessExecutor) executeInit(containerId string, containerSpec spec.Spec, fifo string) (int, error) {
@@ -52,11 +53,12 @@ func (f *fakeCreateProcessExecutor) executeInit(containerId string, containerSpe
 	return f.initPid, f.initErr
 }
 
-func (f *fakeCreateProcessExecutor) executeShim(containerId string, containerSpec spec.Spec, fifo string) (int, error) {
+func (f *fakeCreateProcessExecutor) executeShim(containerId string, containerSpec spec.Spec, fifo string, tty bool) (int, error) {
 	f.shimCalls = append(f.shimCalls, createProcessCall{
 		containerId: containerId,
 		fifo:        fifo,
 		entrypoint:  append([]string(nil), containerSpec.Process.Args...),
+		tty:         tty,
 	})
 	_ = os.MkdirAll(utils.ContainerDir(containerId), 0755)
 	_ = os.WriteFile(utils.InitPidFilePath(containerId), []byte("4321\n"), 0644)
@@ -134,7 +136,7 @@ func TestContainerCreatorCreateRunsLifecyclePipeline(t *testing.T) {
 	setupCreateSpecFile(t, containerId, containerSpec)
 	specLoader := &fakeDeleteSpecLoader{spec: containerSpec}
 	fifoCreator := &fakeCreateFifoCreator{}
-	processExecutor := &fakeCreateProcessExecutor{initPid: 1234}
+	processExecutor := &fakeCreateProcessExecutor{shimPid: 2222}
 	cgroupPreparer := &fakeCreateCgroupPreparer{}
 	networkPreparer := &fakeCreateNetworkPreparer{}
 	statusManager := &fakeDeleteStatusManager{}
@@ -165,10 +167,11 @@ func TestContainerCreatorCreateRunsLifecyclePipeline(t *testing.T) {
 	}}, statusManager.createdStatuses)
 	assert.Equal(t, []deleteHookCall{{containerId: containerId, hooks: containerSpec.Hooks.CreateRuntime}}, hookController.createRuntimeCalls)
 	assert.Equal(t, []string{utils.FifoPath(containerId)}, fifoCreator.calls)
-	assert.Equal(t, []createProcessCall{{containerId: containerId, fifo: utils.FifoPath(containerId), entrypoint: []string{"/bin/sh"}}}, processExecutor.initCalls)
-	assert.Equal(t, []createPrepareCall{{containerId: containerId, pid: 1234, spec: containerSpec}}, cgroupPreparer.calls)
-	assert.Equal(t, []createPrepareCall{{containerId: containerId, pid: 1234, annotation: containerSpec.Annotations}}, networkPreparer.calls)
-	assert.Equal(t, []deleteStatusUpdate{{containerId: containerId, status: status.CREATED, pid: 1234, shimPid: 0}}, statusManager.updates)
+	assert.Empty(t, processExecutor.initCalls)
+	assert.Equal(t, []createProcessCall{{containerId: containerId, fifo: utils.FifoPath(containerId), entrypoint: []string{"/bin/sh"}, tty: false}}, processExecutor.shimCalls)
+	assert.Equal(t, []createPrepareCall{{containerId: containerId, pid: 4321, spec: containerSpec}}, cgroupPreparer.calls)
+	assert.Equal(t, []createPrepareCall{{containerId: containerId, pid: 4321, annotation: containerSpec.Annotations}}, networkPreparer.calls)
+	assert.Equal(t, []deleteStatusUpdate{{containerId: containerId, status: status.CREATED, pid: 4321, shimPid: 2222}}, statusManager.updates)
 	assert.Equal(t, []deleteHookCall{{containerId: containerId, hooks: containerSpec.Hooks.CreateContainer}}, hookController.createContainerCalls)
 }
 
@@ -197,7 +200,7 @@ func TestContainerCreatorCreateTTYUsesShimPidAndInitPidFile(t *testing.T) {
 	// == assert ==
 	require.NoError(t, err)
 	assert.Empty(t, processExecutor.initCalls)
-	assert.Len(t, processExecutor.shimCalls, 1)
+	assert.Equal(t, []createProcessCall{{containerId: containerId, fifo: utils.FifoPath(containerId), entrypoint: []string{"/bin/sh"}, tty: true}}, processExecutor.shimCalls)
 	assert.Contains(t, statusManager.updates, deleteStatusUpdate{
 		containerId: containerId,
 		status:      status.CREATED,

--- a/internal/droplet/container/kill.go
+++ b/internal/droplet/container/kill.go
@@ -181,12 +181,13 @@ func (c *ContainerKill) Kill(opt KillOption) (err error) {
 }
 
 func (c *ContainerKill) cleanupShim(containerId string) error {
-	// remove tty.sock
-	if err := c.syscallHandler.Remove(utils.SockPath(containerId)); err != nil {
+	// remove tty.sock. Non-TTY containers also run through shim/supervisor,
+	// but they do not create a TTY socket. Missing files are therefore expected.
+	if err := c.syscallHandler.Remove(utils.SockPath(containerId)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	// remove init.pid
-	if err := c.syscallHandler.Remove(utils.InitPidFilePath(containerId)); err != nil {
+	if err := c.syscallHandler.Remove(utils.InitPidFilePath(containerId)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	return nil

--- a/internal/droplet/container/shim.go
+++ b/internal/droplet/container/shim.go
@@ -35,13 +35,22 @@ type ContainerShim struct {
 	containerStatusManager status.ContainerStatusManager
 }
 
-func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []string) (err error) {
+type ShimExecuteOption struct {
+	ContainerId string
+	Fifo        string
+	Entrypoint  []string
+	Tty         bool
+}
+
+func (c *ContainerShim) Execute(opt ShimExecuteOption) (err error) {
 	var (
 		spec  spec.Spec
 		event = "shim"
 		stage string
 		pid   int
 	)
+
+	containerId := opt.ContainerId
 
 	// audit log
 	defer func() {
@@ -67,54 +76,98 @@ func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []st
 		return err
 	}
 
-	// 2. pty
-	stage = "open_pty"
-	ptmx, tty, err := pty.Open()
-	if err != nil {
-		return err
-	}
-
-	// 3. console socket listen
-	stage = "listen_socket"
-	sockPath := utils.SockPath(containerId)
-	ln, err := net.Listen("unix", sockPath)
-	if err != nil {
-		return err
-	}
-
-	// open log
+	// open shim log
 	stage = "open_log"
-	shimLog, err := os.OpenFile(utils.ShimLogPath(containerId), os.O_CREATE|os.O_WRONLY, 0640)
+	shimLog, err := os.OpenFile(utils.ShimLogPath(containerId), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
 	if err != nil {
 		return err
 	}
 	defer shimLog.Close()
 	logger := log.New(shimLog, "shim: ", log.LstdFlags|log.Lmicroseconds)
-	consoleLog, err := os.OpenFile(utils.ConsoleLogPath(containerId), os.O_CREATE|os.O_WRONLY, 0640)
-	if err != nil {
-		return err
-	}
-	defer consoleLog.Close()
 
-	// 4. prepare init subcommand
+	// 2. prepare init subcommand
 	stage = "prepare_init_command"
-	initArgs := append([]string{"init", containerId, fifo}, entrypoint...)
+	initArgs := append([]string{"init", containerId, opt.Fifo}, opt.Entrypoint...)
 	cmd := c.commandFactory.Command(utils.SelfBinPath(), initArgs...)
 
-	// set stdio to tty
-	cmd.SetStdin(tty)
-	cmd.SetStdout(tty)
-	cmd.SetStderr(tty)
+	// 3. configure stdio.
+	// TTY mode keeps the existing pty/socket attach path.
+	// Non-TTY mode still uses shim as a supervisor, but stdin is /dev/null and
+	// stdout/stderr are written to init.log just like the previous direct init path.
+	var (
+		ptmx     *os.File
+		tty      *os.File
+		ln       net.Listener
+		sockPath string
+	)
+	if opt.Tty {
+		stage = "open_pty"
+		ptmx, tty, err = pty.Open()
+		if err != nil {
+			return err
+		}
+		defer ptmx.Close()
+		defer tty.Close()
+
+		stage = "listen_socket"
+		sockPath = utils.SockPath(containerId)
+		ln, err = net.Listen("unix", sockPath)
+		if err != nil {
+			return err
+		}
+		defer ln.Close()
+
+		consoleLog, err := os.OpenFile(utils.ConsoleLogPath(containerId), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
+		if err != nil {
+			return err
+		}
+		defer consoleLog.Close()
+
+		cmd.SetStdin(tty)
+		cmd.SetStdout(tty)
+		cmd.SetStderr(tty)
+
+		// Start accepting attach connections before init starts. The attach client
+		// may connect immediately after create/start returns.
+		h := newHub(ptmx, consoleLog, logger)
+		h.startPump()
+		go c.acceptLoop(ln, h, logger)
+	} else {
+		stage = "open_init_log"
+		logPath := utils.InitLogPath(containerId)
+		initLog, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0640)
+		if err != nil {
+			return err
+		}
+		defer initLog.Close()
+		if rootlessConfig, ok := rootlessConfigFromSpec(spec); ok {
+			if err := prepareRootlessInitLog(logPath, rootlessConfig); err != nil {
+				return err
+			}
+		}
+
+		devNull, err := os.OpenFile(os.DevNull, os.O_RDONLY, 0)
+		if err != nil {
+			return err
+		}
+		defer devNull.Close()
+
+		cmd.SetStdin(devNull)
+		cmd.SetStdout(initLog)
+		cmd.SetStderr(initLog)
+	}
 
 	// apply SysProcAttr
 	procAttr := buildProcAttrForContainer(spec)
 	sysProcAttr := buildSysProcAttr(procAttr)
 	sysProcAttr.Setsid = true
-	sysProcAttr.Setctty = true
-	sysProcAttr.Ctty = 0
+	if opt.Tty {
+		sysProcAttr.Setctty = true
+		sysProcAttr.Ctty = 0
+	}
 	cmd.SetSysProcAttr(sysProcAttr)
 
-	// 5. execute init subcommand
+	// 4. execute init subcommand
 	stage = "exec_init"
 	err = cmd.Start()
 	if err != nil {
@@ -123,9 +176,9 @@ func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []st
 	}
 	initPid := cmd.Pid()
 	pid = initPid
-	logger.Printf("init started pid=%d", initPid)
+	logger.Printf("init started pid=%d tty=%t", initPid, opt.Tty)
 
-	// 6. create pidfile
+	// 5. create pidfile
 	stage = "create_pid_file"
 	err = c.writeInitPid(containerId, initPid)
 	if err != nil {
@@ -133,23 +186,19 @@ func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []st
 		return err
 	}
 
-	// 6. close tty
-	stage = "close_tty"
-	_ = tty.Close()
+	if opt.Tty {
+		// The child process already inherited the slave side. Close the shim copy so
+		// ptmx observes EOF once the container process exits.
+		stage = "close_tty"
+		_ = tty.Close()
+	}
 
-	// 7. accept and proxy
-	stage = "data_accept"
-	h := newHub(ptmx, consoleLog, logger)
-	h.startPump()
-	go c.acceptLoop(ln, h, logger)
-
-	// 8. wait init process
-	//err = cmd.Wait()
+	// 6. wait init process
 	stage = "wait_init"
 	waitErr := cmd.Wait()
 	logger.Printf("init exited: %v", waitErr)
 
-	// 9. update state
+	// 7. update state
 	stage = "update_state"
 	err = c.containerStatusManager.UpdateStatus(
 		containerId,
@@ -161,8 +210,8 @@ func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []st
 		return err
 	}
 
-	// 10. set exit code, reason and message
-	stage = "update exit status"
+	// 8. set exit code, reason and message
+	stage = "update_exit_status"
 	exitCode := c.InitExitCode(cmd)
 	err = c.containerStatusManager.UpdateExitCode(containerId, exitCode)
 	if err != nil {
@@ -179,8 +228,12 @@ func (c *ContainerShim) Execute(containerId string, fifo string, entrypoint []st
 		return err
 	}
 
-	_ = ln.Close()
-	_ = os.Remove(sockPath)
+	if ln != nil {
+		_ = ln.Close()
+	}
+	if sockPath != "" {
+		_ = os.Remove(sockPath)
+	}
 
 	return waitErr
 }

--- a/scripts/e2e/raind.sh
+++ b/scripts/e2e/raind.sh
@@ -305,6 +305,90 @@ assert_sudo_path_absent() {
   sudo_cmd test ! -e "${path}" || fail "expected path to be absent: ${path}"
 }
 
+runtime_exit_status_matches() {
+  local cid="$1"
+  local expected_exit_code="$2"
+  local expected_reason="$3"
+  local expected_message="$4"
+  local state_path="/etc/raind/container/${cid}/state.json"
+
+  sudo_cmd test -f "${state_path}" && sudo_cmd jq -e \
+    --arg cid "${cid}" \
+    --argjson code "${expected_exit_code}" \
+    --arg reason "${expected_reason}" \
+    --arg message "${expected_message}" \
+    '.id == $cid and .status == "stopped" and .pid == 0 and .shimPid == 0 and .exit_code == $code and .reason == $reason and .message == $message' \
+    "${state_path}" >/dev/null 2>&1
+}
+
+csm_exit_status_matches() {
+  local cid="$1"
+  local expected_exit_code="$2"
+  local expected_reason="$3"
+  local expected_message="$4"
+  local csm_path="/etc/raind/store/csm.json"
+
+  sudo_cmd test -f "${csm_path}" && sudo_cmd jq -e \
+    --arg cid "${cid}" \
+    --argjson code "${expected_exit_code}" \
+    --arg reason "${expected_reason}" \
+    --arg message "${expected_message}" \
+    '.containers[$cid].state == "stopped" and .containers[$cid].pid == 0 and .containers[$cid].exit_code == $code and .containers[$cid].reason == $reason and .containers[$cid].message == $message' \
+    "${csm_path}" >/dev/null 2>&1
+}
+
+assert_container_exit_status() {
+  local cid="$1"
+  local expected_exit_code="$2"
+  local expected_reason="$3"
+  local expected_message="$4"
+  local state_path="/etc/raind/container/${cid}/state.json"
+  local csm_path="/etc/raind/store/csm.json"
+
+  # The runtime shim writes the final status to state.json first. Condenser's
+  # monitor then observes process-down and reconciles CSM from that runtime
+  # state. Short-lived containers can therefore be visible as running in CSM for
+  # a brief window after state.json has already reached stopped. Poll both files
+  # for the same final status instead of asserting CSM immediately.
+  for _ in $(seq 1 120); do
+    if runtime_exit_status_matches "${cid}" "${expected_exit_code}" "${expected_reason}" "${expected_message}" && \
+       csm_exit_status_matches "${cid}" "${expected_exit_code}" "${expected_reason}" "${expected_message}"; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  if ! runtime_exit_status_matches "${cid}" "${expected_exit_code}" "${expected_reason}" "${expected_message}"; then
+    printf '%s\n' "--- ${state_path} ---" >&2
+    sudo_cmd cat "${state_path}" >&2 || true
+    fail "unexpected runtime exit status for ${cid}"
+  fi
+
+  printf '%s\n' "--- ${csm_path} ---" >&2
+  sudo_cmd cat "${csm_path}" >&2 || true
+  fail "unexpected CSM exit status for ${cid}"
+}
+
+wait_container_stopped() {
+  local cid="$1"
+  local state_path="/etc/raind/container/${cid}/state.json"
+  local csm_path="/etc/raind/store/csm.json"
+
+  for _ in $(seq 1 120); do
+    if sudo_cmd test -f "${state_path}" && sudo_cmd jq -e '.status == "stopped"' "${state_path}" >/dev/null 2>&1 && \
+       sudo_cmd test -f "${csm_path}" && sudo_cmd jq -e --arg cid "${cid}" '.containers[$cid].state == "stopped"' "${csm_path}" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.25
+  done
+
+  printf '%s\n' "--- ${state_path} ---" >&2
+  sudo_cmd cat "${state_path}" >&2 || true
+  printf '%s\n' "--- ${csm_path} ---" >&2
+  sudo_cmd cat "${csm_path}" >&2 || true
+  fail "timed out waiting for container to stop: ${cid}"
+}
+
 extract_created_id() {
   local name="$1"
   awk '/: .* (created|applied)$/ || /: .* created / { print $2; exit }' "${E2E_WORK_DIR}/${name}.out"
@@ -598,6 +682,38 @@ test_container_deploy() {
   run_raind_allow_empty container-logs container logs --line 20 "${cid}"
   run_raind_allow_empty container-stop container stop "${cid}"
   run_raind_allow_empty container-rm container rm "${cid}"
+}
+
+test_container_exit_status() {
+  local cid
+
+  log "container exit status test"
+
+  run_raind non-tty-exit-42 container run --name "e2e-exit-42-${SUFFIX}" alpine:latest sh -c 'exit 42'
+  cid="$(extract_created_id non-tty-exit-42)"
+  cid="$(resolve_container_id "${cid}" "e2e-exit-42-${SUFFIX}")"
+  wait_container_stopped "${cid}"
+  assert_container_exit_status "${cid}" 42 "Error" "exit status 42"
+  run_raind_allow_empty non-tty-exit-42-rm container rm "${cid}"
+
+  run_raind non-tty-shell-eof container run --name "e2e-shell-eof-${SUFFIX}" alpine:latest
+  cid="$(extract_created_id non-tty-shell-eof)"
+  cid="$(resolve_container_id "${cid}" "e2e-shell-eof-${SUFFIX}")"
+  wait_container_stopped "${cid}"
+  assert_container_exit_status "${cid}" 0 "Completed" "exit code: 0"
+  run_raind_allow_empty non-tty-shell-eof-rm container rm "${cid}"
+
+  # Do not use `container run -t` here: run attaches to the TTY after start,
+  # which is useful for humans but can block a non-interactive e2e script. Use
+  # create -t + start -t instead so the runtime still exercises the TTY shim
+  # path while the CLI remains non-interactive.
+  run_raind tty-exit-42-create container create -t --name "e2e-tty-exit-42-${SUFFIX}" alpine:latest sh -c 'exit 42'
+  cid="$(extract_created_id tty-exit-42-create)"
+  cid="$(resolve_container_id "${cid}" "e2e-tty-exit-42-${SUFFIX}")"
+  run_raind tty-exit-42-start container start -t "${cid}"
+  wait_container_stopped "${cid}"
+  assert_container_exit_status "${cid}" 42 "Error" "exit status 42"
+  run_raind_allow_empty tty-exit-42-rm container rm "${cid}"
 }
 
 test_dev_security_profile_container() {
@@ -1095,6 +1211,7 @@ main() {
   test_network
   test_policy
   test_container_deploy
+  test_container_exit_status
   test_dev_security_profile_container
   test_deploy_security_profile_container
   test_restricted_security_profile_container

--- a/scripts/integ/raind.sh
+++ b/scripts/integ/raind.sh
@@ -19,6 +19,25 @@ fail() {
     printf '%s\n' '--- condenser log ---' >&2
     tail -120 "${LOG_PATH}" >&2 || true
   fi
+  if sudo_cmd test -f /etc/raind/store/csm.json 2>/dev/null; then
+    printf '%s\n' '--- csm.json ---' >&2
+    sudo_cmd cat /etc/raind/store/csm.json >&2 || true
+  fi
+  if sudo_cmd test -f /etc/raind/store/psm.json 2>/dev/null; then
+    printf '%s\n' '--- psm.json ---' >&2
+    sudo_cmd cat /etc/raind/store/psm.json >&2 || true
+  fi
+  if sudo_cmd test -d /etc/raind/container 2>/dev/null; then
+    printf '%s\n' '--- recent container logs ---' >&2
+    sudo_cmd find /etc/raind/container -maxdepth 3 \( -path '*/logs/init.log' -o -path '*/logs/console.log' \) -type f -printf '%T@ %p\n' 2>/dev/null \
+      | sort -nr \
+      | head -8 \
+      | awk '{ $1=""; sub(/^ /, ""); print }' \
+      | while IFS= read -r runtime_log; do
+          printf '%s\n' "----- ${runtime_log} -----" >&2
+          sudo_cmd tail -40 "${runtime_log}" >&2 || true
+        done
+  fi
   exit 1
 }
 
@@ -62,6 +81,9 @@ prepare_runtime() {
     /etc/raind/image/layers \
     /var/log/raind \
     /sys/fs/cgroup/raind
+
+  reset_integ_runtime_state
+
   sudo_cmd chmod 0755 /etc/raind /etc/raind/log /etc/raind/cert /etc/raind/store /var/log/raind
 
   for controller in cpu memory pids io; do
@@ -69,6 +91,26 @@ prepare_runtime() {
       sudo_cmd sh -c "echo +${controller} > /sys/fs/cgroup/raind/cgroup.subtree_control 2>/dev/null || true"
     fi
   done
+}
+
+reset_integ_runtime_state() {
+  log "reset integration runtime state"
+
+  # The integration suite exercises CLI/API contracts and should not depend on
+  # leftover runtime state from previous manual runs or failed tests. This is
+  # especially important now that short-lived non-TTY containers are supervised
+  # by shim and correctly leave terminal CSM entries behind.
+  sudo_cmd rm -rf /etc/raind/store/*
+  sudo_cmd rm -rf /etc/raind/container/*
+  sudo_cmd rm -f /etc/raind/log/droplet_audit.log
+
+  if sudo_cmd test -d /run/netns; then
+    sudo_cmd sh -c 'for ns in /run/netns/rn_*; do [ -e "$ns" ] || continue; umount "$ns" 2>/dev/null || true; rm -f "$ns"; done'
+  fi
+
+  if sudo_cmd test -d /sys/fs/cgroup/raind; then
+    sudo_cmd find /sys/fs/cgroup/raind -mindepth 1 -depth -type d -exec rmdir {} + 2>/dev/null || true
+  fi
 }
 
 cleanup_stale_condenser() {
@@ -141,7 +183,11 @@ run_raind() {
   local out="${E2E_WORK_DIR}/${name}.out"
 
   log "raind $*"
-  sudo_cmd env PATH="${PATH}" "${RAIND_BIN}" "$@" >"${out}" 2>&1
+  if ! sudo_cmd env PATH="${PATH}" "${RAIND_BIN}" "$@" >"${out}" 2>&1; then
+    printf '%s\n' "--- ${out} ---" >&2
+    cat "${out}" >&2 || true
+    fail "raind $* failed"
+  fi
   [[ -s "${out}" ]] || fail "raind $* produced no output"
 }
 
@@ -151,7 +197,11 @@ run_raind_allow_empty() {
   local out="${E2E_WORK_DIR}/${name}.out"
 
   log "raind $*"
-  sudo_cmd env PATH="${PATH}" "${RAIND_BIN}" "$@" >"${out}" 2>&1
+  if ! sudo_cmd env PATH="${PATH}" "${RAIND_BIN}" "$@" >"${out}" 2>&1; then
+    printf '%s\n' "--- ${out} ---" >&2
+    cat "${out}" >&2 || true
+    fail "raind $* failed"
+  fi
 }
 
 assert_raind_fails() {
@@ -364,8 +414,14 @@ run_cli_write_checks() {
   [[ -n "${pod_id}" ]] || fail "pod create did not print pod id"
   run_raind pod-ls-after-create resource pod ls
   assert_output_contains pod-ls-after-create "${pod_name}"
-  run_raind_allow_empty pod-start resource pod start "${pod_id}"
-  run_raind_allow_empty pod-stop resource pod stop "${pod_id}"
+  # Keep integration pod checks focused on CLI/API persistence contracts.
+  # Runtime lifecycle behavior for pod/deployment/service resources is covered
+  # by scripts/e2e/raind.sh. Empty CLI-created pods are reconciled by the pod
+  # controller and may be recreated with a new pod ID, so remove this API-only
+  # pod immediately after the list assertion instead of keeping the original
+  # ID around for late cleanup.
+  run_raind pod-rm resource pod rm "${pod_id}"
+  assert_output_contains pod-rm "removed"
 
   cat >"${E2E_WORK_DIR}/service.yaml" <<YAML
 apiVersion: v1
@@ -439,8 +495,6 @@ YAML
   run_raind resource-namespace-rm resource rm -f "${E2E_WORK_DIR}/resource-namespace-service.yaml"
   assert_output_contains resource-namespace-rm "namespace:"
   assert_output_contains resource-namespace-rm "service:"
-
-  run_raind_allow_empty pod-rm resource pod rm "${pod_id}"
 
   assert_raind_fails service-create-invalid resource service create -f "${E2E_WORK_DIR}/missing-service.yaml"
   assert_raind_fails container-create-missing-image container create raind/e2e-missing:latest --name "e2e-cli-missing-$$"


### PR DESCRIPTION
Fixes: #23 

## Summary

This PR stabilizes container exit status handling by unifying TTY and non-TTY container startup through the shim/supervisor path.

Main changes:

* Run both TTY and non-TTY containers through the shim supervisor.
* Make TTY handling optional inside the shim.
* Keep non-TTY stdio behavior compatible by writing stdout/stderr to `init.log`.
* Reconcile final container exit status from `state.json` into `csm.json` when the condenser monitor detects a process-down event.
* Treat `process down detected` as a fallback state instead of a final exit status when a real shim-collected status is available.
* Update integration and e2e tests to match the new lifecycle behavior and wait for final CSM status convergence.

## Motivation

Naturally exited containers could previously be reported in `csm.json` as:

```json
{
  "exit_code": -1,
  "reason": "Error",
  "message": "process down detected."
}
```

even when the actual container process exited successfully or with a known non-zero code.

This happened because non-TTY containers were started without a persistent supervisor that could wait for the init process and collect its final exit status. The condenser monitor could detect that the process was gone, but it could not reliably distinguish successful exit, non-zero exit, signal termination, or monitor fallback.

The TTY path already used a shim and was able to collect accurate exit status in `state.json`. This PR extends that model to non-TTY containers as well, so all container startup modes have a consistent final-status path.

This also improves build/runtime correctness for short-lived containers and Dockerfile `RUN`-like workflows where accurate exit-code propagation is required.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [x] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [ ] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [x] Droplet runtime
* [x] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [x] namespaces
* [ ] mount / rootfs / pivot_root
* [x] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR changes the container process supervision path, but it is not intended to change namespace, cgroup, capability, seccomp, AppArmor, rootfs, or network security policy behavior.

The main lifecycle change is that non-TTY containers are now launched under the shim supervisor, matching the existing TTY path. The init process should still be started with the same OCI spec-derived namespace, cgroup, capability, seccomp, and LSM configuration as before. The shim only supervises the init process, waits for it, records the final exit status, and optionally handles TTY attach behavior when TTY is enabled.

Expected behavior:

* TTY containers continue to use the shim with PTY/attach support.
* Non-TTY containers use the shim without PTY/attach support.
* Non-TTY stdout/stderr continue to be written to `init.log`.
* Final exit status is collected by the shim and reconciled into CSM.
* `process down detected` remains available only as a fallback when a final status cannot be read.

## Testing

Commands run:

```sh
# Integration tests
workshop run -- test-integ

# E2E tests
workshop run -- test-e2e

# Manual TTY exit-status checks
raind container run -t alpine sh -c 'exit 0'
raind container run -t alpine sh -c 'exit 1'
raind container run -t alpine sh -c 'exit 42'
raind container run -t nginx
raind container stop <container>

# Manual non-TTY exit-status checks
raind container run alpine sh -c 'exit 42'
raind container run alpine
raind container run nginx
raind container logs <nginx-container>
sudo kill <nginx-init-pid>
sudo kill -9 <nginx-init-pid>

# State verification
sudo cat /etc/raind/container/<container-id>/state.json
sudo cat /etc/raind/store/csm.json
```

Results:

* `workshop run -- test-integ` passed.
* `workshop run -- test-e2e` passed.
* TTY containers now consistently report final exit status in both `state.json` and `csm.json`.
* Non-TTY containers now consistently report final exit status in both `state.json` and `csm.json`.
* `exit 0` is reported as:

```json
{
  "exit_code": 0,
  "reason": "Completed",
  "message": "exit code: 0"
}
```

* `exit 42` is reported as:

```json
{
  "exit_code": 42,
  "reason": "Error",
  "message": "exit status 42"
}
```

* SIGKILL termination is reported as:

```json
{
  "exit_code": 137,
  "reason": "Error",
  "message": "signal: killed"
}
```

* Non-TTY nginx writes logs through `init.log`, and `raind container logs` works as expected.
* `state.json` and `csm.json` converge to the same final container status after natural exit, non-zero exit, graceful termination, and SIGKILL termination.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below

The external CLI behavior is intended to remain compatible.

Internally, non-TTY containers are now supervised by the shim, so `state.json` may contain both `pid` and `shimPid` while the container is running. This aligns non-TTY behavior with the existing TTY supervision model and improves final exit status reporting without changing user-facing container commands.
