### PR TITLE
fix build container exit code waiter

### DIFF
--- a/internal/condenser/core/image/service_build.go
+++ b/internal/condenser/core/image/service_build.go
@@ -675,12 +675,13 @@ func (s *ImageService) runCommandInContainer(state *buildState, bridge string, s
 	if err := runtimeHandler.Start(runtime.StartModel{ContainerId: containerId, Tty: true}); err != nil {
 		return err
 	}
-	// RUN is executed as the container's init process.
+	// RUN is executed as the container's init process. Judge it only by a
+	// finalized exit status. A process-down monitor fallback is not a success.
 	info, err := waitBuildContainerStopped(csmHandler, containerId, 10*time.Minute)
 	if err != nil {
 		return err
 	}
-	if info.ExitCode != 0 && info.Message != "process down detected." {
+	if info.ExitCode != 0 {
 		return buildRunFailedError(info, containerDir)
 	}
 	_ = removeBuildRunScript(upperDir)
@@ -1151,24 +1152,70 @@ func removeBuildRunScript(mergedDir string) error {
 	return nil
 }
 
+var buildStatusPollInterval = 500 * time.Millisecond
+var buildExitStatusFinalizeTimeout = 5 * time.Second
+
 func waitBuildContainerStopped(csmHandler csm.CsmHandler, containerId string, timeout time.Duration) (csm.ContainerInfo, error) {
-	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
+	stopDeadline := time.Now().Add(timeout)
+	var finalDeadline time.Time
+	var lastInfo csm.ContainerInfo
+
+	for {
+		now := time.Now()
+		if finalDeadline.IsZero() && now.After(stopDeadline) {
+			return csm.ContainerInfo{}, fmt.Errorf("timeout waiting for build container to stop: %s", containerId)
+		}
+		if !finalDeadline.IsZero() && now.After(finalDeadline) {
+			return csm.ContainerInfo{}, buildRunExitStatusNotFinalError(lastInfo)
+		}
+
 		info, err := csmHandler.GetContainerById(containerId)
 		if err == nil {
+			lastInfo = info
 			switch info.State {
 			case "stopped":
-				return info, nil
+				if isBuildExitStatusFinal(info) {
+					return info, nil
+				}
+				if finalDeadline.IsZero() {
+					finalDeadline = time.Now().Add(buildExitStatusFinalizeTimeout)
+				}
 			case "running", "created", "creating":
-				time.Sleep(500 * time.Millisecond)
-				continue
+				// Still waiting for the build RUN container to terminate.
 			default:
 				return csm.ContainerInfo{}, fmt.Errorf("unexpected container state: %s", info.State)
 			}
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(buildStatusPollInterval)
 	}
-	return csm.ContainerInfo{}, fmt.Errorf("timeout waiting for build container to stop: %s", containerId)
+}
+
+func isBuildExitStatusFinal(info csm.ContainerInfo) bool {
+	if info.State != "stopped" {
+		return false
+	}
+	if info.ExitCode < 0 {
+		return false
+	}
+	if info.ExitCode != 0 {
+		return true
+	}
+	return strings.TrimSpace(info.Reason) != "" || strings.TrimSpace(info.Message) != ""
+}
+
+func buildRunExitStatusNotFinalError(info csm.ContainerInfo) error {
+	msg := fmt.Sprintf("RUN command exit status was not finalized: container_id=%s", info.ContainerId)
+	if strings.TrimSpace(info.State) != "" {
+		msg += ", state=" + info.State
+	}
+	msg += fmt.Sprintf(", exit_code=%d", info.ExitCode)
+	if strings.TrimSpace(info.Reason) != "" {
+		msg += ", reason=" + info.Reason
+	}
+	if strings.TrimSpace(info.Message) != "" {
+		msg += ", message=" + info.Message
+	}
+	return errors.New(msg)
 }
 
 func buildRunFailedError(info csm.ContainerInfo, containerDir string) error {

--- a/internal/condenser/core/image/service_build_dockerfile_test.go
+++ b/internal/condenser/core/image/service_build_dockerfile_test.go
@@ -3,7 +3,11 @@ package image
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"raind/internal/condenser/store/csm"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -77,4 +81,56 @@ func TestApplyEnvSupportsQuotedValues(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, state.env, "APP_NAME=hello world")
 	assert.Contains(t, state.env, "LOG_LEVEL=debug")
+}
+
+func TestIsBuildExitStatusFinal(t *testing.T) {
+	assert.False(t, isBuildExitStatusFinal(csm.ContainerInfo{State: "running", ExitCode: 0}))
+	assert.False(t, isBuildExitStatusFinal(csm.ContainerInfo{State: "stopped", ExitCode: -1, Reason: "Error", Message: "process down detected."}))
+	assert.False(t, isBuildExitStatusFinal(csm.ContainerInfo{State: "stopped", ExitCode: 0}))
+	assert.True(t, isBuildExitStatusFinal(csm.ContainerInfo{State: "stopped", ExitCode: 0, Reason: "Completed", Message: "exit code: 0"}))
+	assert.True(t, isBuildExitStatusFinal(csm.ContainerInfo{State: "stopped", ExitCode: 42, Reason: "Error", Message: "exit status 42"}))
+}
+
+func TestWaitBuildContainerStoppedWaitsForFinalizedExitStatus(t *testing.T) {
+	oldPoll := buildStatusPollInterval
+	oldFinalize := buildExitStatusFinalizeTimeout
+	buildStatusPollInterval = 5 * time.Millisecond
+	buildExitStatusFinalizeTimeout = 500 * time.Millisecond
+	t.Cleanup(func() {
+		buildStatusPollInterval = oldPoll
+		buildExitStatusFinalizeTimeout = oldFinalize
+	})
+
+	manager := csm.NewCsmManager(csm.NewCsmStore(filepath.Join(t.TempDir(), "csm.json")))
+	require.NoError(t, manager.StoreContainer("build-test", "stopped", 0, false, "build", "build", []string{"/bin/sh"}, "build-test", "", "", ""))
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = manager.UpdateExitStatus("build-test", 42, "Error", "exit status 42")
+	}()
+
+	info, err := waitBuildContainerStopped(manager, "build-test", time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, 42, info.ExitCode)
+	assert.Equal(t, "exit status 42", info.Message)
+}
+
+func TestWaitBuildContainerStoppedFailsWhenExitStatusIsNotFinalized(t *testing.T) {
+	oldPoll := buildStatusPollInterval
+	oldFinalize := buildExitStatusFinalizeTimeout
+	buildStatusPollInterval = 5 * time.Millisecond
+	buildExitStatusFinalizeTimeout = 30 * time.Millisecond
+	t.Cleanup(func() {
+		buildStatusPollInterval = oldPoll
+		buildExitStatusFinalizeTimeout = oldFinalize
+	})
+
+	manager := csm.NewCsmManager(csm.NewCsmStore(filepath.Join(t.TempDir(), "csm.json")))
+	require.NoError(t, manager.StoreContainer("build-test", "stopped", 0, false, "build", "build", []string{"/bin/sh"}, "build-test", "", "", ""))
+	require.NoError(t, manager.UpdateExitStatus("build-test", -1, "Error", "process down detected."))
+
+	_, err := waitBuildContainerStopped(manager, "build-test", time.Second)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "exit status was not finalized"), err.Error())
+	assert.True(t, strings.Contains(err.Error(), "process down detected"), err.Error())
 }


### PR DESCRIPTION
Fixes: #22 

## Summary

This PR fixes Dockerfile `RUN` result handling during `raind image build`.

Main changes:

* Judge build-time `RUN` instructions by the finalized process exit code.
* Stop treating `process down detected.` as a successful `RUN` result.
* Treat process-down fallback states as intermediate/unknown until the final exit status is available.
* Add bounded polling for build-time container exit status finalization.
* Fail with a clear error if the final `RUN` exit status cannot be determined.
* Add tests for finalized RUN exit status handling and process-down race cases.

## Motivation

`raind image build` could previously misclassify Dockerfile `RUN` instruction results when the monitor observed that a build-time process had exited before the final exit code was available.

This caused two unreliable behaviors:

1. A failed `RUN` command could be incorrectly reported as completed if `process down detected.` was treated as success.
2. A successful short-lived `RUN` command, such as `npm ci`, could be incorrectly reported as failed with:

```text
exit_code=-1, reason=Error, message=process down detected.
```

In real multi-stage builds, this could hide the actual failure and later surface as a misleading `COPY --from=<stage>` error because the expected artifact, such as `/app/dist`, was never produced.

The runtime now has a reliable final exit-status path through shim/supervisor status collection and CSM reconciliation (#24). This PR updates the build-side judgment logic to rely on that finalized status instead of treating monitor fallback messages as final results.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [x] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [ ] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [ ] Droplet runtime
* [x] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [x] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

No security-sensitive runtime isolation behavior is changed by this PR.

This PR changes build-result judgment logic in the image builder. It does not modify namespace setup, mount/rootfs handling, cgroup placement, capabilities, seccomp, AppArmor, rootless UID/GID mappings, certificate/API authentication, networking policy, or bind mount behavior.

The expected security behavior remains unchanged. Build-time containers continue to run with the existing runtime configuration; this PR only changes how their finalized exit status is interpreted by the image builder.

## Testing

Commands run:

```sh
# Apply patch validation
git apply --check raind-build-run-final-exit-status.patch

# Integration tests
workshop run -- test-integ

# E2E tests
workshop run -- test-e2e

# Vue/Vite multi-stage build verification
cd ~/container-deploy/test
raind image build -t local/vue-multistage-test:latest .

# Run generated image
raind container run --name vue-multistage -p 18080:80 local/vue-multistage-test:latest

# Verify container state and logs
raind container ls
raind container logs vue-multistage

# Verify served output
curl http://172.17.20.200:18080/

# Verify stored image
raind image ls
sudo ls -l /etc/raind/image/layers/vue-multistage-test/latest/
sudo ls -l /etc/raind/image/layers/vue-multistage-test/latest/rootfs/
sudo ls -l /etc/raind/image/layers/vue-multistage-test/latest/rootfs/usr/share/nginx/html
sudo cat /etc/raind/image/layers/vue-multistage-test/latest/config.json
```

Results:

* `workshop run -- test-integ` passed.
* `workshop run -- test-e2e` passed.
* Vue/Vite multi-stage image build completed successfully.
* `RUN npm ci` completed successfully.
* `RUN npm run build && test -f /app/dist/index.html && ls -la /app/dist` completed successfully.
* `COPY --from=builder /app/dist /usr/share/nginx/html` completed successfully.
* Final image was stored as `local/vue-multistage-test:latest`.
* Final image started successfully as an nginx container.
* Published port `18080` served the generated Vue `index.html`.
* Final rootfs contained the expected nginx runtime files and copied Vue build output:

```text
/etc/raind/image/layers/vue-multistage-test/latest/rootfs/usr/share/nginx/html
├── 50x.html
├── assets/
├── health.txt
└── index.html
```

* Final image config preserved the nginx final-stage configuration:

```json
{
  "config": {
    "Cmd": ["nginx", "-g", "daemon off;"],
    "Entrypoint": ["/docker-entrypoint.sh"],
    "WorkingDir": "/",
    "User": ""
  }
}
```

This confirms that the builder stage produced `/app/dist`, the final nginx stage copied it correctly, and the generated image can be run and served successfully.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below

No user-facing CLI or Dockerfile compatibility changes are intended.

The behavior change is limited to build-result correctness: a `RUN` instruction is now judged by its finalized process exit code. `process down detected.` is no longer treated as success by itself. If the final exit status cannot be determined within the bounded wait period, the build fails with a clear exit-status-finalization error instead of continuing with an ambiguous result.
