### PR TITLE
fix symlink overwrite

### DIFF
--- a/internal/condenser/core/image/service_build.go
+++ b/internal/condenser/core/image/service_build.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
+	"golang.org/x/sys/unix"
 )
 
 type buildState struct {
@@ -1521,11 +1522,11 @@ func ExtractTarToDirWithOptions(r io.Reader, dst string, opt ExtractTarOptions) 
 		}
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(target, os.FileMode(hdr.Mode)); err != nil {
+			if err := ensureSafeExtractionDir(dst, target, os.FileMode(hdr.Mode).Perm()); err != nil {
 				return err
 			}
-		case tar.TypeReg:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		case tar.TypeReg, tar.TypeRegA:
+			if err := ensureSafeExtractionDir(dst, filepath.Dir(target), 0o755); err != nil {
 				return err
 			}
 			if hdr.Size < 0 {
@@ -1534,7 +1535,7 @@ func ExtractTarToDirWithOptions(r io.Reader, dst string, opt ExtractTarOptions) 
 			if hdr.Size > opt.MaxFile {
 				return fmt.Errorf("build context file too large: %s max=%d bytes", hdr.Name, opt.MaxFile)
 			}
-			f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode))
+			f, err := openRegularFileNoFollow(target, os.FileMode(hdr.Mode).Perm())
 			if err != nil {
 				return err
 			}
@@ -1546,7 +1547,10 @@ func ExtractTarToDirWithOptions(r io.Reader, dst string, opt ExtractTarOptions) 
 				return err
 			}
 		case tar.TypeSymlink:
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			if err := ensureSafeExtractionDir(dst, filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			if err := ensureExtractionTargetAbsentOrNotSymlink(target, hdr.Name); err != nil {
 				return err
 			}
 			if err := os.Symlink(hdr.Linkname, target); err != nil {
@@ -1556,6 +1560,83 @@ func ExtractTarToDirWithOptions(r io.Reader, dst string, opt ExtractTarOptions) 
 			// ignore other types
 		}
 	}
+}
+
+func ensureSafeExtractionDir(root string, dir string, perm fs.FileMode) error {
+	root = filepath.Clean(root)
+	dir = filepath.Clean(dir)
+	rel, err := filepath.Rel(root, dir)
+	if err != nil {
+		return err
+	}
+	if rel == "." {
+		return nil
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return fmt.Errorf("invalid extraction directory: %s", dir)
+	}
+
+	current := root
+	for _, part := range strings.Split(rel, string(os.PathSeparator)) {
+		if part == "" || part == "." {
+			continue
+		}
+		if part == ".." {
+			return fmt.Errorf("invalid extraction directory: %s", dir)
+		}
+		current = filepath.Join(current, part)
+		info, err := os.Lstat(current)
+		if err == nil {
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to follow symlink while extracting tar: %s", current)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("not a directory while extracting tar: %s", current)
+			}
+			continue
+		}
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.Mkdir(current, perm); err != nil {
+			if !os.IsExist(err) {
+				return err
+			}
+			info, statErr := os.Lstat(current)
+			if statErr != nil {
+				return statErr
+			}
+			if info.Mode()&os.ModeSymlink != 0 {
+				return fmt.Errorf("refusing to follow symlink while extracting tar: %s", current)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("not a directory while extracting tar: %s", current)
+			}
+		}
+	}
+	return nil
+}
+
+func ensureExtractionTargetAbsentOrNotSymlink(target string, name string) error {
+	info, err := os.Lstat(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to overwrite symlink while extracting tar: %s", name)
+	}
+	return nil
+}
+
+func openRegularFileNoFollow(target string, mode fs.FileMode) (*os.File, error) {
+	fd, err := unix.Open(target, unix.O_CREAT|unix.O_WRONLY|unix.O_TRUNC|unix.O_NOFOLLOW|unix.O_CLOEXEC, uint32(mode.Perm()))
+	if err != nil {
+		return nil, err
+	}
+	return os.NewFile(uintptr(fd), target), nil
 }
 
 type buildContextLimitReader struct {

--- a/internal/condenser/core/image/tar_extract_test.go
+++ b/internal/condenser/core/image/tar_extract_test.go
@@ -3,6 +3,8 @@ package image
 import (
 	"archive/tar"
 	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -54,6 +56,74 @@ func TestExtractTarToDirWithOptionsRejectsTooManyEntries(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too many entries")
+}
+
+func TestExtractTarToDirWithOptionsRejectsSymlinkOverwrite(t *testing.T) {
+	outside := filepath.Join(t.TempDir(), "outside-target")
+	require.NoError(t, os.WriteFile(outside, []byte("safe\n"), 0o666))
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "overwrite-me",
+		Typeflag: tar.TypeSymlink,
+		Linkname: outside,
+		Mode:     0o777,
+	}))
+	payload := []byte("overwritten\n")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "overwrite-me",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+	}))
+	_, err := tw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	err = ExtractTarToDirWithOptions(bytes.NewReader(buf.Bytes()), t.TempDir(), ExtractTarOptions{
+		MaxBytes:   int64(buf.Len() + 1024),
+		MaxFile:    1024,
+		MaxEntries: 10,
+	})
+
+	require.Error(t, err)
+	got, readErr := os.ReadFile(outside)
+	require.NoError(t, readErr)
+	assert.Equal(t, "safe\n", string(got))
+}
+
+func TestExtractTarToDirWithOptionsRejectsParentDirectorySymlink(t *testing.T) {
+	outside := t.TempDir()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "dir",
+		Typeflag: tar.TypeSymlink,
+		Linkname: outside,
+		Mode:     0o777,
+	}))
+	payload := []byte("data\n")
+	require.NoError(t, tw.WriteHeader(&tar.Header{
+		Name:     "dir/file.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+	}))
+	_, err := tw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+
+	err = ExtractTarToDirWithOptions(bytes.NewReader(buf.Bytes()), t.TempDir(), ExtractTarOptions{
+		MaxBytes:   int64(buf.Len() + 1024),
+		MaxFile:    1024,
+		MaxEntries: 10,
+	})
+
+	require.Error(t, err)
+	_, statErr := os.Stat(filepath.Join(outside, "file.txt"))
+	assert.True(t, os.IsNotExist(statErr), "outside file should not be created")
 }
 
 func buildTestTar(t *testing.T, files map[string]string) []byte {


### PR DESCRIPTION
Fixes: #26 

## Summary

Fix a symlink overwrite issue in build context tar extraction.

This PR hardens the tar extraction path used during image builds so that regular file entries cannot overwrite files outside the build context extraction directory through symlinks. It also adds regression tests for the confirmed symlink overwrite case and parent-directory symlink handling.

## Motivation

A crafted build context tar could create a symlink inside the temporary build context directory and then include a regular file entry with the same path. During extraction, the regular file open path could follow the symlink and truncate/write to the symlink target outside the extraction directory.

This was confirmed with a PoC where a build context tar contained:

```text
Dockerfile
overwrite-me -> /tmp/raind-symlink-overwrite-poc-dir/proof-target
overwrite-me  # regular file entry with payload
```

Before this fix, posting the tar to the image build endpoint overwrote the external proof target. After this fix, the build context is rejected and the external file remains unchanged.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [x] Security hardening

## Affected areas

* [ ] CLI
* [ ] Condenser API / controller
* [ ] Droplet runtime
* [ ] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [x] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [x] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [x] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR affects user-controlled build context extraction. Build contexts are user-provided tar archives, so extraction must not allow writes outside the temporary extraction root.

The expected security behavior is:

* tar entry paths must remain inside the extraction directory;
* regular file extraction must not follow symlinks;
* parent directory components used during extraction must not be symlinks;
* crafted tar archives must not be able to overwrite host files outside the build context extraction directory.

The confirmed PoC is now blocked. The external proof target remains unchanged after the build request.

## Testing

Commands run:

```sh
git apply raind_fix_tar_extraction_symlink_overwrite.patch
git apply --check raind_fix_tar_extraction_symlink_overwrite.patch

# Rebuild/restart raind/condenser with the patched code, then run:
cd raind_symlink_overwrite_poc
./run_poc.sh
```

Results:

Before the fix, the PoC succeeded and overwrote the external proof target:

```text
{"status":"success","message":"build completed","data":{"image":"library/symlink-overwrite-poc:latest"}}

[*] target after request:  OVERWRITTEN_BY_RAIND_BUILD_CONTEXT_EXTRACTOR
[!] VULNERABLE: external target was overwritten during tar extraction.
```

After the fix, the build context is rejected and the external proof target remains unchanged:

```text
{"status":"fail","message":"invalid build context: too many levels of symbolic links"}

[*] target after request:  SAFE_BEFORE_RAIND_BUILD
[+] not reproduced: target was not overwritten.
```

`go test` was not run in the initial patch-generation environment because the available Go toolchain was older than the repository’s required Go version. The relevant package tests should be run in a Go 1.25-compatible environment:

```sh
go test ./internal/condenser/core/image
```

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below

This change should not affect normal build contexts. It only rejects unsafe tar extraction behavior involving symlink traversal during file creation.
