### PR TITLE
fix symlink traversal

### DIFF
--- a/internal/condenser/core/image/service_build.go
+++ b/internal/condenser/core/image/service_build.go
@@ -388,24 +388,25 @@ func (s *ImageService) applyCopy(state *buildState, contextDir string, stages []
 		if err != nil {
 			return err
 		}
-		targetPath := dstPath
-		if len(spec.sources) > 1 {
-			targetPath = filepath.Join(dstPath, filepath.Base(filepath.Clean(src)))
-		}
-		info, err := os.Lstat(srcPath)
+		resolvedSrcPath, info, err := resolveCopySourceWithinRoot(sourceRoot, srcPath, src)
 		if err != nil {
 			return err
 		}
+		targetPath := dstPath
+		sourceBase := filepath.Base(filepath.Clean(src))
+		if len(spec.sources) > 1 {
+			targetPath = filepath.Join(dstPath, sourceBase)
+		}
 		if info.IsDir() {
-			if err := copyDir(srcPath, targetPath); err != nil {
+			if err := copyDir(resolvedSrcPath, targetPath); err != nil {
 				return err
 			}
 			continue
 		}
 		if dstInfo, err := os.Lstat(targetPath); err == nil && dstInfo.IsDir() {
-			targetPath = filepath.Join(targetPath, filepath.Base(srcPath))
+			targetPath = filepath.Join(targetPath, sourceBase)
 		}
-		if err := copyFile(srcPath, targetPath, info.Mode()); err != nil {
+		if err := copyFile(resolvedSrcPath, targetPath, info.Mode()); err != nil {
 			return err
 		}
 		if spec.chmod != "" {
@@ -999,6 +1000,35 @@ func safeBuildSourceJoin(root string, src string, allowAbs bool) (string, error)
 		clean = strings.TrimPrefix(clean, string(os.PathSeparator))
 	}
 	return safeJoin(root, clean)
+}
+
+func resolveCopySourceWithinRoot(root string, srcPath string, originalSource string) (string, os.FileInfo, error) {
+	resolvedRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", nil, err
+	}
+	resolvedSrc, err := filepath.EvalSymlinks(srcPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if !pathWithinRoot(resolvedRoot, resolvedSrc) {
+		return "", nil, fmt.Errorf("COPY/ADD source escapes build context: %s", originalSource)
+	}
+	info, err := os.Stat(resolvedSrc)
+	if err != nil {
+		return "", nil, err
+	}
+	return resolvedSrc, info, nil
+}
+
+func pathWithinRoot(root string, target string) bool {
+	root = filepath.Clean(root)
+	target = filepath.Clean(target)
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) && !filepath.IsAbs(rel)
 }
 
 func parseChmod(value string) (fs.FileMode, error) {

--- a/internal/condenser/core/image/service_build_dockerfile_test.go
+++ b/internal/condenser/core/image/service_build_dockerfile_test.go
@@ -72,6 +72,60 @@ func TestApplyCopySupportsQuotedMultipleSources(t *testing.T) {
 	assert.Equal(t, "two", string(gotTwo))
 }
 
+func TestApplyCopyRejectsSymlinkEscapingBuildContext(t *testing.T) {
+	contextDir := t.TempDir()
+	outsideDir := t.TempDir()
+	currentRoot := t.TempDir()
+	realSecret := filepath.Join(outsideDir, "secret.txt")
+	require.NoError(t, os.WriteFile(realSecret, []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(realSecret, filepath.Join(contextDir, "linked-secret")))
+
+	state := buildState{rootfsPath: currentRoot, workdir: "/"}
+	service := &ImageService{}
+
+	err := service.applyCopy(&state, contextDir, nil, nil, "linked-secret /proof/copied-secret")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "COPY/ADD source escapes build context")
+	_, statErr := os.Stat(filepath.Join(currentRoot, "proof", "copied-secret"))
+	assert.True(t, os.IsNotExist(statErr), "external secret should not be copied into the image rootfs")
+}
+
+func TestApplyCopyRejectsParentSymlinkEscapingBuildContext(t *testing.T) {
+	contextDir := t.TempDir()
+	outsideDir := t.TempDir()
+	currentRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outsideDir, "secret.txt"), []byte("secret"), 0o644))
+	require.NoError(t, os.Symlink(outsideDir, filepath.Join(contextDir, "linked-dir")))
+
+	state := buildState{rootfsPath: currentRoot, workdir: "/"}
+	service := &ImageService{}
+
+	err := service.applyCopy(&state, contextDir, nil, nil, "linked-dir/secret.txt /proof/copied-secret")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "COPY/ADD source escapes build context")
+	_, statErr := os.Stat(filepath.Join(currentRoot, "proof", "copied-secret"))
+	assert.True(t, os.IsNotExist(statErr), "external secret should not be copied into the image rootfs")
+}
+
+func TestApplyCopyAllowsSymlinkResolvingInsideBuildContext(t *testing.T) {
+	contextDir := t.TempDir()
+	currentRoot := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(contextDir, "real.txt"), []byte("hello"), 0o644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(contextDir, "linked.txt")))
+
+	state := buildState{rootfsPath: currentRoot, workdir: "/"}
+	service := &ImageService{}
+
+	err := service.applyCopy(&state, contextDir, nil, nil, "linked.txt /proof/copied")
+
+	require.NoError(t, err)
+	got, err := os.ReadFile(filepath.Join(currentRoot, "proof", "copied"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+}
+
 func TestApplyEnvSupportsQuotedValues(t *testing.T) {
 	state := newBuildState()
 	service := &ImageService{}


### PR DESCRIPTION
Fixes: #27 

## Summary

Fix symlink traversal in Dockerfile `COPY` and `ADD` source handling.

This PR prevents `COPY` and `ADD` from reading files outside the build context through symlinks. Source paths are now resolved safely, and the build fails if the resolved path escapes the build context root.

## Motivation

A build context could contain a symlink that points to a file outside the build context:

```text
linked-secret -> /tmp/raind-copy-add-symlink-poc-dir/secret.txt
```

Then a Dockerfile could copy that external file into the image:

```Dockerfile
COPY linked-secret /proof/copied-from-copy
ADD linked-secret /proof/copied-from-add
```

Before this fix, both `COPY` and `ADD` followed the symlink and copied the external file content into the image. This was confirmed with a PoC where the Dockerfile included a `RUN test ...` assertion, and the build succeeded for both instructions.

This change is needed to preserve build context isolation. User-controlled build contexts should not be able to read arbitrary host files via symlink traversal.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [x] Security hardening

## Affected areas

* [ ] CLI
* [ ] Condenser API / controller
* [ ] Droplet runtime
* [ ] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [x] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [x] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [x] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR affects user-controlled image build contexts. Build contexts may contain symlinks, so Dockerfile `COPY` and `ADD` must ensure that source paths do not resolve outside the build context root.

The expected security behavior is:

* `COPY` and `ADD` must not read files outside the build context.
* symlink sources that resolve outside the build context must be rejected.
* parent directory symlinks that resolve outside the build context must also be rejected.
* symlinks that resolve safely inside the build context may be handled normally.
* external host files must not be copied into the image through build context symlink traversal.

## Testing

Commands run:

```sh
git apply raind_fix_copy_add_symlink_traversal.patch

# Rebuild/restart raind/condenser with the patched code, then run:
cd raind_copy_add_symlink_traversal_poc
./run_poc.sh
```

Results:

Before the fix, both `COPY` and `ADD` followed a build context symlink and copied the external file content into the image:

```text
[!] COPY appears VULNERABLE: build succeeded and the external secret was copied via symlink traversal.
    The RUN assertion passed, so /proof/copied-from-copy contained: RAIND_COPY_ADD_SYMLINK_TRAVERSAL_SECRET

[!] ADD appears VULNERABLE: build succeeded and the external secret was copied via symlink traversal.
    The RUN assertion passed, so /proof/copied-from-add contained: RAIND_COPY_ADD_SYMLINK_TRAVERSAL_SECRET
```

After the fix, both `COPY` and `ADD` reject the symlink source because it resolves outside the build context:

```text
COPY             linked-secret /proof/copied-from-copy
2026/06/17 11:05:03 build failed: COPY/ADD source escapes build context: linked-secret

[+] COPY not reproduced: build failed.
    Exit status: 1
```

```text
ADD              linked-secret /proof/copied-from-add
2026/06/17 11:05:04 build failed: COPY/ADD source escapes build context: linked-secret

[+] ADD not reproduced: build failed.
    Exit status: 1
```

The external secret was not copied into the image after the fix.

The relevant package tests should also be run in a Go 1.25-compatible environment:

```sh
go test ./internal/condenser/core/image
```

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below

This change should not affect normal build contexts. It only rejects unsafe `COPY`/`ADD` sources that resolve outside the build context through symlinks.