### PR TITLE
add cli path traversal check

### DIFF
--- a/internal/raind/core/image/build.go
+++ b/internal/raind/core/image/build.go
@@ -102,10 +102,11 @@ func (s *ServiceImageBuild) Build(param ServiceImageBuildModel) error {
 
 func resolveBuildFile(contextDir string, requested string) (string, error) {
 	if requested != "" {
-		if _, err := os.Stat(filepath.Join(contextDir, requested)); err != nil {
+		buildFile, err := resolveRequestedBuildFile(contextDir, requested)
+		if err != nil {
 			return "", err
 		}
-		return requested, nil
+		return buildFile, nil
 	}
 	for _, candidate := range []string{"Dripfile", "Dockerfile"} {
 		if _, err := os.Stat(filepath.Join(contextDir, candidate)); err == nil {
@@ -113,6 +114,29 @@ func resolveBuildFile(contextDir string, requested string) (string, error) {
 		}
 	}
 	return "", os.ErrNotExist
+}
+
+func resolveRequestedBuildFile(contextDir string, requested string) (string, error) {
+	cleaned := filepath.Clean(requested)
+	if filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("dripfile path must be relative to build context: %s", requested)
+	}
+
+	root, err := filepath.Abs(contextDir)
+	if err != nil {
+		return "", err
+	}
+	full := filepath.Join(root, cleaned)
+
+	rel, err := filepath.Rel(root, full)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) || filepath.IsAbs(rel) {
+		return "", fmt.Errorf("dripfile path escapes build context: %s", requested)
+	}
+
+	if _, err := os.Stat(full); err != nil {
+		return "", err
+	}
+	return rel, nil
 }
 
 func sanitizeTarName(tag string) string {

--- a/internal/raind/core/image/build_test.go
+++ b/internal/raind/core/image/build_test.go
@@ -35,3 +35,40 @@ func TestResolveBuildFileUsesExplicitFile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "custom.Dockerfile", got)
 }
+
+func TestResolveBuildFileRejectsPathEscapingContext(t *testing.T) {
+	dir := t.TempDir()
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "Dripfile")
+	rel, err := filepath.Rel(dir, outside)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(outside, []byte("FROM scratch\n"), 0o644))
+
+	_, err = resolveBuildFile(dir, rel)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes build context")
+}
+
+func TestResolveBuildFileRejectsAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "Dripfile")
+	require.NoError(t, os.WriteFile(outside, []byte("FROM scratch\n"), 0o644))
+
+	_, err := resolveBuildFile(dir, outside)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be relative")
+}
+
+func TestResolveBuildFileNormalizesExplicitFileInsideContext(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dripfile"), []byte("FROM scratch\n"), 0o644))
+
+	got, err := resolveBuildFile(dir, filepath.Join("subdir", "..", "Dripfile"))
+
+	require.NoError(t, err)
+	assert.Equal(t, "Dripfile", got)
+}


### PR DESCRIPTION
## Summary

Fix validation for explicitly specified build files passed via `--file`, `--dockerfile`, or `--dripfile`.

This change rejects absolute paths and paths that escape the build context, such as `../Dripfile`, before the build request is sent.

## Motivation

Fixes #30.

The CLI previously checked whether the requested build file existed by joining it with the build context path. As a result, paths outside the build context could pass local validation if the target file existed.

Build file paths should be constrained to the build context on the client side as well, matching the expected behavior enforced by the server-side validation.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [x] Security hardening

## Affected areas

* [x] CLI
* [ ] Condenser API / controller
* [ ] Droplet runtime
* [ ] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [x] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR hardens CLI-side handling of user-controlled build file paths.

Explicitly specified build files must now be relative paths contained within the build context. Absolute paths and relative paths that resolve outside the build context are rejected before the build request is sent.

This prevents local CLI validation from accepting paths such as `../Dripfile` or `/tmp/Dripfile`.

## Testing

Commands run:

```sh
git apply --check /mnt/data/raind_issue30.patch
```

Results:

`git apply --check` succeeded.

Unit tests were not run in this environment because the repository requires Go 1.25.0, and the local environment attempted to download the Go toolchain from `proxy.golang.org`, which is not reachable from this environment.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below
