### PR TITLE
fix body size limit

### DIFF
--- a/internal/condenser/api/http/bottle/handler.go
+++ b/internal/condenser/api/http/bottle/handler.go
@@ -2,7 +2,6 @@ package bottle
 
 import (
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	apimodel "raind/internal/condenser/api/http/utils"
@@ -43,9 +42,9 @@ type RequestHandler struct {
 // @Success 201 {object} apimodel.ApiResponse
 // @Router /v1/bottle [post]
 func (h *RequestHandler) RegisterBottle(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
+	body, err := apimodel.ReadLimitedBody(r.Body, apimodel.MaxManifestBodyBytes)
 	if err != nil {
-		apimodel.RespondFail(w, http.StatusBadRequest, "invalid body: "+err.Error(), nil)
+		apimodel.RespondFail(w, apimodel.DecodeErrorStatus(err), "invalid body: "+err.Error(), nil)
 		return
 	}
 

--- a/internal/condenser/api/http/bottle/handler_test.go
+++ b/internal/condenser/api/http/bottle/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	apimodel "raind/internal/condenser/api/http/utils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +19,20 @@ func TestRegisterBottleInvalidYAMLReturnsFailEnvelope(t *testing.T) {
 	NewRequestHandler().RegisterBottle(rec, httptest.NewRequest(http.MethodPost, "/v1/bottle", strings.NewReader("bottle: [")))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var got struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "fail", got.Status)
+}
+
+func TestRegisterBottleRejectsTooLargeBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(strings.Repeat("a", int(apimodel.MaxManifestBodyBytes)+1))
+
+	NewRequestHandler().RegisterBottle(rec, httptest.NewRequest(http.MethodPost, "/v1/bottle", body))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	var got struct {
 		Status string `json:"status"`
 	}

--- a/internal/condenser/api/http/pod/handler.go
+++ b/internal/condenser/api/http/pod/handler.go
@@ -108,9 +108,9 @@ func (h *RequestHandler) CreatePod(w http.ResponseWriter, r *http.Request) {
 // @Success 201 {object} apimodel.ApiResponse
 // @Router /v1/resource/apply [post]
 func (h *RequestHandler) ApplyPodYaml(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
+	body, err := apimodel.ReadLimitedBody(r.Body, apimodel.MaxManifestBodyBytes)
 	if err != nil {
-		apimodel.RespondFail(w, http.StatusBadRequest, "invalid body: "+err.Error(), nil)
+		apimodel.RespondFail(w, apimodel.DecodeErrorStatus(err), "invalid body: "+err.Error(), nil)
 		return
 	}
 
@@ -438,9 +438,9 @@ func (h *RequestHandler) ApplyPodYaml(w http.ResponseWriter, r *http.Request) {
 // @Success 200 {object} apimodel.ApiResponse
 // @Router /v1/resource/delete [post]
 func (h *RequestHandler) DeleteResourceYaml(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
+	body, err := apimodel.ReadLimitedBody(r.Body, apimodel.MaxManifestBodyBytes)
 	if err != nil {
-		apimodel.RespondFail(w, http.StatusBadRequest, "invalid body: "+err.Error(), nil)
+		apimodel.RespondFail(w, apimodel.DecodeErrorStatus(err), "invalid body: "+err.Error(), nil)
 		return
 	}
 

--- a/internal/condenser/api/http/pod/handler_test.go
+++ b/internal/condenser/api/http/pod/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	apimodel "raind/internal/condenser/api/http/utils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +19,34 @@ func TestApplyPodYamlUnsupportedKindReturnsFailEnvelope(t *testing.T) {
 	NewRequestHandler().ApplyPodYaml(rec, httptest.NewRequest(http.MethodPost, "/v1/resource/apply", strings.NewReader("kind: ConfigMap\nmetadata:\n  name: x\n")))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var got struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "fail", got.Status)
+}
+
+func TestApplyPodYamlRejectsTooLargeBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(strings.Repeat("a", int(apimodel.MaxManifestBodyBytes)+1))
+
+	NewRequestHandler().ApplyPodYaml(rec, httptest.NewRequest(http.MethodPost, "/v1/resource/apply", body))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	var got struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "fail", got.Status)
+}
+
+func TestDeleteResourceYamlRejectsTooLargeBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(strings.Repeat("a", int(apimodel.MaxManifestBodyBytes)+1))
+
+	NewRequestHandler().DeleteResourceYaml(rec, httptest.NewRequest(http.MethodPost, "/v1/resource/delete", body))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	var got struct {
 		Status string `json:"status"`
 	}

--- a/internal/condenser/api/http/securityprofile/handler.go
+++ b/internal/condenser/api/http/securityprofile/handler.go
@@ -1,7 +1,6 @@
 package securityprofile
 
 import (
-	"encoding/json"
 	"net/http"
 	apimodel "raind/internal/condenser/api/http/utils"
 	core "raind/internal/condenser/core/securityprofile"
@@ -62,8 +61,8 @@ func (h *RequestHandler) ShowSecurityProfile(w http.ResponseWriter, r *http.Requ
 // @Router /v1/security/profiles [post]
 func (h *RequestHandler) RegisterSecurityProfile(w http.ResponseWriter, r *http.Request) {
 	var req RegisterSecurityProfileRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		apimodel.RespondFail(w, http.StatusBadRequest, "invalid security profile request: "+err.Error(), RegisterSecurityProfileResponse{})
+	if err := apimodel.DecodeRequestBody(r, &req); err != nil {
+		apimodel.RespondFail(w, apimodel.DecodeErrorStatus(err), "invalid security profile request: "+err.Error(), RegisterSecurityProfileResponse{})
 		return
 	}
 	profile, err := h.service.Register(req)

--- a/internal/condenser/api/http/securityprofile/handler_test.go
+++ b/internal/condenser/api/http/securityprofile/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	apimodel "raind/internal/condenser/api/http/utils"
 	core "raind/internal/condenser/core/securityprofile"
 
 	"github.com/go-chi/chi/v5"
@@ -157,6 +158,28 @@ func TestRegisterSecurityProfile(t *testing.T) {
 	assert.Equal(t, core.ProfileTypeCustom, resp.Data.Profile.Type)
 	assert.Contains(t, resp.Data.Profile.Capabilities.Base, "CAP_SYS_PTRACE")
 	assert.NotContains(t, resp.Data.Profile.Capabilities.Base, "CAP_NET_RAW")
+}
+
+func TestRegisterSecurityProfileRejectsTooLargeBody(t *testing.T) {
+	handler := &RequestHandler{service: core.NewServiceWithStoreDir(t.TempDir())}
+	body := strings.NewReader(strings.Repeat("a", int(apimodel.MaxJSONBodyBytes)+1))
+	req := httptest.NewRequest(http.MethodPost, "/v1/security/profiles", body)
+	w := httptest.NewRecorder()
+
+	handler.RegisterSecurityProfile(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestRegisterSecurityProfileRejectsUnknownFields(t *testing.T) {
+	handler := &RequestHandler{service: core.NewServiceWithStoreDir(t.TempDir())}
+	reqBody := `{"apiVersion":"raind.io/v1","kind":"SecurityProfile","metadata":{"name":"custom-dev"},"spec":{"extends":"dev"},"unknown":true}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/security/profiles", strings.NewReader(reqBody))
+	w := httptest.NewRecorder()
+
+	handler.RegisterSecurityProfile(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestRegisterSecurityProfileRequiresExtends(t *testing.T) {

--- a/internal/condenser/api/http/service/handler.go
+++ b/internal/condenser/api/http/service/handler.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"io"
 	"net/http"
 	"time"
 
@@ -33,9 +32,9 @@ type RequestHandler struct {
 // @Success 201 {object} apimodel.ApiResponse
 // @Router /v1/services [post]
 func (h *RequestHandler) CreateService(w http.ResponseWriter, r *http.Request) {
-	body, err := io.ReadAll(r.Body)
+	body, err := apimodel.ReadLimitedBody(r.Body, apimodel.MaxManifestBodyBytes)
 	if err != nil {
-		apimodel.RespondFail(w, http.StatusBadRequest, "read body failed: "+err.Error(), CreateServiceResponse{ServiceId: ""})
+		apimodel.RespondFail(w, apimodel.DecodeErrorStatus(err), "read body failed: "+err.Error(), CreateServiceResponse{ServiceId: ""})
 		return
 	}
 	manifest, err := coreService.DecodeK8sServiceManifest(body)

--- a/internal/condenser/api/http/service/handler_test.go
+++ b/internal/condenser/api/http/service/handler_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	apimodel "raind/internal/condenser/api/http/utils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,6 +19,20 @@ func TestCreateServiceInvalidYAMLReturnsFailEnvelope(t *testing.T) {
 	NewRequestHandler().CreateService(rec, httptest.NewRequest(http.MethodPost, "/v1/services", strings.NewReader("kind: [")))
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var got struct {
+		Status string `json:"status"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	assert.Equal(t, "fail", got.Status)
+}
+
+func TestCreateServiceRejectsTooLargeBody(t *testing.T) {
+	rec := httptest.NewRecorder()
+	body := strings.NewReader(strings.Repeat("a", int(apimodel.MaxManifestBodyBytes)+1))
+
+	NewRequestHandler().CreateService(rec, httptest.NewRequest(http.MethodPost, "/v1/services", body))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	var got struct {
 		Status string `json:"status"`
 	}

--- a/internal/condenser/api/http/utils/model.go
+++ b/internal/condenser/api/http/utils/model.go
@@ -9,7 +9,10 @@ import (
 	"net/http"
 )
 
-const MaxJSONBodyBytes int64 = 1 << 20
+const (
+	MaxJSONBodyBytes     int64 = 1 << 20
+	MaxManifestBodyBytes int64 = 10 << 20
+)
 
 var ErrRequestBodyTooLarge = errors.New("request body too large")
 
@@ -30,7 +33,7 @@ type StreamEvent struct {
 }
 
 func DecodeRequestBody(r *http.Request, v any) error {
-	body, err := readLimitedBody(r.Body, MaxJSONBodyBytes)
+	body, err := ReadLimitedBody(r.Body, MaxJSONBodyBytes)
 	if err != nil {
 		return err
 	}
@@ -53,7 +56,7 @@ func DecodeErrorStatus(err error) int {
 	return http.StatusBadRequest
 }
 
-func readLimitedBody(r io.Reader, limit int64) ([]byte, error) {
+func ReadLimitedBody(r io.Reader, limit int64) ([]byte, error) {
 	lr := &io.LimitedReader{R: r, N: limit + 1}
 	body, err := io.ReadAll(lr)
 	if err != nil {

--- a/internal/condenser/api/http/utils/model_test.go
+++ b/internal/condenser/api/http/utils/model_test.go
@@ -85,6 +85,16 @@ func TestDecodeRequestBodyRejectsMultipleJSONValues(t *testing.T) {
 	assert.Contains(t, err.Error(), "multiple JSON values")
 }
 
+func TestReadLimitedBodyRejectsTooLargeManifest(t *testing.T) {
+	body := strings.NewReader(strings.Repeat("a", int(MaxManifestBodyBytes)+1))
+
+	_, err := ReadLimitedBody(body, MaxManifestBodyBytes)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrRequestBodyTooLarge)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, DecodeErrorStatus(err))
+}
+
 func TestStreamJsonWritesNDJSONEvent(t *testing.T) {
 	rec := httptest.NewRecorder()
 


### PR DESCRIPTION
## Summary

Add bounded request-body reads for manifest-related API handlers and align security profile JSON decoding with the shared request decoder.

This change introduces a shared manifest body size limit and applies it to handlers that previously read request bodies without an explicit limit.

## Motivation

Fixes #31.

Some authenticated API endpoints read manifest request bodies directly with `io.ReadAll(r.Body)`, which could allocate memory proportional to the request size. This could allow an authenticated client to submit an excessively large request body and cause unnecessary memory pressure.

The existing JSON request helper already enforces a maximum body size. This PR extends the same pattern to manifest-style request bodies and also updates the security profile handler to use the shared JSON decoding helper for stricter, consistent validation.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [x] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [ ] Droplet runtime
* [ ] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [ ] Networking / policy / netflow
* [x] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR does not directly change any of the listed low-level isolation, authentication, networking, or host-path behaviors.

It does harden authenticated API request handling by preventing unbounded request-body allocation for manifest-related endpoints. Oversized manifest bodies are now rejected with `413 Request Entity Too Large`, and security profile JSON requests are decoded through the shared JSON request helper with the existing JSON body size limit and stricter validation behavior.

## Testing

Commands run:

```sh
git apply --check /mnt/data/raind_issue31.patch
```

Results:

`git apply --check` succeeded.

Unit tests were not run in this environment because the repository requires Go 1.25.0, while the available local Go version is 1.23.2 with `GOTOOLCHAIN=local`.

Expected test coverage added by this PR:

* Oversized service manifest requests are rejected.
* Oversized pod apply manifest requests are rejected.
* Oversized pod delete manifest requests are rejected.
* Oversized bottle manifest requests are rejected.
* Oversized security profile JSON requests are rejected.
* Security profile JSON decoding rejects unknown fields through the shared decoder.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below
