### PR TITLE
fix ws origin restrict

### DIFF
--- a/internal/condenser/api/http/websocket/handler.go
+++ b/internal/condenser/api/http/websocket/handler.go
@@ -8,11 +8,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"raind/internal/condenser/api/http/logger"
 	"raind/internal/condenser/store/csm"
 	"raind/internal/condenser/utils"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -61,9 +63,10 @@ func (r StaticResolver) ConsoleSockPath(containerId string) (string, error) {
 }
 
 type Handler struct {
-	Resolver   SockResolver
-	Upgrader   websocket.Upgrader
-	csmHandler csm.CsmHandler
+	Resolver       SockResolver
+	Upgrader       websocket.Upgrader
+	AllowedOrigins []string
+	csmHandler     csm.CsmHandler
 }
 
 // ServeHTTP handles GET /containers/{id}/attach (WebSocket)
@@ -101,7 +104,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	up := h.Upgrader
 	if up.CheckOrigin == nil {
-		up.CheckOrigin = func(r *http.Request) bool { return true }
+		up.CheckOrigin = h.checkOrigin
 	}
 
 	ws, err := up.Upgrade(w, r, nil)
@@ -175,6 +178,30 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wg.Wait()
 
 	_ = e
+}
+
+func (h *Handler) checkOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	if sameOrigin(r, origin) {
+		return true
+	}
+	for _, allowed := range h.AllowedOrigins {
+		if origin == allowed {
+			return true
+		}
+	}
+	return false
+}
+
+func sameOrigin(r *http.Request, origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.EqualFold(u.Host, r.Host)
 }
 
 // dialUnixWithRetry tries to connect to a unix domain socket until it succeeds

--- a/internal/condenser/api/http/websocket/handler_test.go
+++ b/internal/condenser/api/http/websocket/handler_test.go
@@ -1,0 +1,56 @@
+package websocket
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckOriginAllowsRequestsWithoutOrigin(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+
+	assert.True(t, h.checkOrigin(req))
+}
+
+func TestCheckOriginAllowsSameOriginRequests(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+	req.Header.Set("Origin", "https://127.0.0.1:7755")
+
+	assert.True(t, h.checkOrigin(req))
+}
+
+func TestCheckOriginRejectsCrossOriginRequestsByDefault(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+	req.Header.Set("Origin", "https://example.invalid")
+
+	assert.False(t, h.checkOrigin(req))
+}
+
+func TestCheckOriginRejectsMalformedOrigin(t *testing.T) {
+	h := &Handler{}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+	req.Header.Set("Origin", "://bad-origin")
+
+	assert.False(t, h.checkOrigin(req))
+}
+
+func TestCheckOriginAllowsConfiguredOrigin(t *testing.T) {
+	h := &Handler{AllowedOrigins: []string{"https://ui.example.test"}}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+	req.Header.Set("Origin", "https://ui.example.test")
+
+	assert.True(t, h.checkOrigin(req))
+}
+
+func TestCheckOriginRejectsUnconfiguredOrigin(t *testing.T) {
+	h := &Handler{AllowedOrigins: []string{"https://ui.example.test"}}
+	req := httptest.NewRequest(http.MethodGet, "https://127.0.0.1:7755/v1/containers/c/attach", nil)
+	req.Header.Set("Origin", "https://example.invalid")
+
+	assert.False(t, h.checkOrigin(req))
+}


### PR DESCRIPTION
## Summary

Harden the default WebSocket Origin policy for container attach and exec attach endpoints.

When no custom `CheckOrigin` function is configured, the WebSocket handler now allows requests without an `Origin` header, allows same-origin browser requests, and rejects cross-origin browser requests by default.

## Motivation

Fixes #32.

The WebSocket handler previously replaced a nil `CheckOrigin` function with one that always returned `true`. This allowed browser-originated WebSocket upgrade requests from arbitrary origins.

These endpoints are primarily used by CLI or non-browser clients, which typically do not send an `Origin` header. For those clients, behavior remains compatible. Browser-originated requests with an `Origin` header are now constrained to same-origin by default, with an explicit allowlist hook available for future use if needed.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [x] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [ ] Droplet runtime
* [x] Container lifecycle
* [x] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR does not directly change any of the listed low-level isolation, authentication, networking, or host-path behaviors.

It does harden WebSocket request handling for attach-related API endpoints. Cross-origin browser WebSocket upgrade requests are rejected by default unless they are same-origin or explicitly allowlisted. Requests without an `Origin` header continue to be accepted for CLI and non-browser clients.

## Testing

Commands run:

```sh
git apply --check /mnt/data/raind_issue32.patch
```

Results:

`git apply --check` succeeded.

Unit tests were not run in this environment because the repository requires Go 1.25.0, and the toolchain download from `proxy.golang.org` is not reachable from this environment.

Expected test coverage added by this PR:

* Requests without an `Origin` header are allowed.
* Same-origin WebSocket requests are allowed.
* Cross-origin WebSocket requests are rejected by default.
* Malformed `Origin` values are rejected.
* Explicitly allowlisted origins are allowed.
* Non-allowlisted origins remain rejected.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below
