### PR TITLE
fix safejoin

### DIFF
--- a/internal/condenser/core/image/service_build.go
+++ b/internal/condenser/core/image/service_build.go
@@ -1299,11 +1299,14 @@ func readBuildLogTail(logPath string, containerDir string) string {
 
 func safeJoin(baseDir string, rel string) (string, error) {
 	clean := filepath.Clean(rel)
-	if strings.HasPrefix(clean, "..") || filepath.IsAbs(clean) {
+	if filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(os.PathSeparator)) {
 		return "", fmt.Errorf("invalid path: %s", rel)
 	}
-	full := filepath.Join(baseDir, clean)
-	if !strings.HasPrefix(full, filepath.Clean(baseDir)+string(os.PathSeparator)) && filepath.Clean(baseDir) != full {
+
+	baseClean := filepath.Clean(baseDir)
+	full := filepath.Join(baseClean, clean)
+	relToBase, err := filepath.Rel(baseClean, full)
+	if err != nil || relToBase == ".." || strings.HasPrefix(relToBase, ".."+string(os.PathSeparator)) || filepath.IsAbs(relToBase) {
 		return "", fmt.Errorf("invalid path: %s", rel)
 	}
 	return full, nil

--- a/internal/condenser/core/image/service_test.go
+++ b/internal/condenser/core/image/service_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -82,6 +83,41 @@ func TestSafeJoinRejectsTarTraversal(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid path")
+}
+
+func TestSafeJoinRejectsParentDirectory(t *testing.T) {
+	_, err := safeJoin("/context", "..")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path")
+}
+
+func TestSafeJoinRejectsAbsolutePath(t *testing.T) {
+	_, err := safeJoin("/context", filepath.Join(string(os.PathSeparator), "absolute", "path"))
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid path")
+}
+
+func TestSafeJoinAllowsNameStartingWithDotDot(t *testing.T) {
+	got, err := safeJoin("/context", "..data")
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/context", "..data"), got)
+}
+
+func TestSafeJoinAllowsNestedNameStartingWithDotDot(t *testing.T) {
+	got, err := safeJoin("/context", filepath.Join("dir", "..data", "file.txt"))
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/context", "dir", "..data", "file.txt"), got)
+}
+
+func TestSafeJoinAllowsDotDotWellKnownName(t *testing.T) {
+	got, err := safeJoin("/context", filepath.Join("..well-known", "config.json"))
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("/context", "..well-known", "config.json"), got)
 }
 
 type fakeRegistryHandler struct {


### PR DESCRIPTION
## Summary

Fix `safeJoin` path validation so valid path names starting with `..` are accepted.

This change allows normal path components such as `..data`, `..well-known`, and `dir/..data/file.txt`, while still rejecting actual parent-directory traversal and absolute paths.

## Motivation

Fixes #34.

The previous validation used a broad `strings.HasPrefix(clean, "..")` check. This rejected legitimate file or directory names that merely start with `..`, even though they do not escape the build context.

The validation now distinguishes actual traversal paths such as `..` and `../secret` from valid names like `..data`.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [ ] Security hardening

## Affected areas

* [ ] CLI
* [ ] Condenser API / controller
* [ ] Droplet runtime
* [ ] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [x] Image handling
* [ ] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [ ] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR does not directly change any of the listed security-sensitive runtime, isolation, authentication, networking, or host-path behaviors.

The existing path traversal protection is preserved: `..`, `../...`, and absolute paths are still rejected. The change narrows the validation so only actual traversal is rejected, while legitimate path names beginning with `..` are accepted.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below
