### PR TITLE
fix port forward setting

### DIFF
--- a/internal/condenser/core/container/service_delete.go
+++ b/internal/condenser/core/container/service_delete.go
@@ -106,6 +106,31 @@ func (s *ContainerService) cleanupForwardRules(containerId string) error {
 	return nil
 }
 
+func (s *ContainerService) restoreForwardRules(containerId string) error {
+	forwards, err := s.ipamHandler.GetForwardInfo(containerId)
+	if err != nil {
+		return err
+	}
+	if len(forwards) == 0 {
+		return nil
+	}
+
+	for _, f := range forwards {
+		if err := s.networkServiceHandler.CreateForwardingRule(
+			containerId,
+			network.ServiceNetworkModel{
+				HostPort:      strconv.Itoa(f.HostPort),
+				ContainerPort: strconv.Itoa(f.ContainerPort),
+				Protocol:      f.Protocol,
+			},
+		); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (s *ContainerService) releaseAddress(containerId string) error {
 	if err := s.ipamHandler.Release(containerId); err != nil {
 		return err

--- a/internal/condenser/core/container/service_start.go
+++ b/internal/condenser/core/container/service_start.go
@@ -48,6 +48,13 @@ func (s *ContainerService) Start(startParameter ServiceStartModel) (string, erro
 				return "", fmt.Errorf("start container failed: %w", err)
 			}
 		}
+		// restore forwarding rules before starting the container.
+		// Forwarding metadata is persisted in IPAM, while iptables rules are runtime state
+		// and can be lost after a host reboot.
+		if err := s.restoreForwardRules(containerId); err != nil {
+			return "", fmt.Errorf("restore forward rule failed: %w", err)
+		}
+
 		// start container
 		if err := s.startContainer(containerId, containerInfo.Tty); err != nil {
 			return "", fmt.Errorf("start container failed: %w", err)

--- a/internal/condenser/core/container/service_test.go
+++ b/internal/condenser/core/container/service_test.go
@@ -93,6 +93,24 @@ func TestContainerServiceStartResolvesNameToID(t *testing.T) {
 	assert.Equal(t, "cid-1", deps.runtime.startedID)
 }
 
+func TestContainerServiceStartRestoresForwardRulesForStoppedContainer(t *testing.T) {
+	deps := newContainerServiceTestDeps(true)
+	deps.csm.storeInfo("cid-1", csm.ContainerInfo{ContainerId: "cid-1", ContainerName: "web", State: "stopped"})
+	deps.ipam.forwards = map[string][]ipam.ForwardInfo{
+		"cid-1": {{HostPort: 8080, ContainerPort: 80, Protocol: "tcp"}},
+	}
+
+	id, err := deps.service.Start(ServiceStartModel{ContainerId: "web"})
+
+	require.NoError(t, err)
+	assert.Equal(t, "cid-1", id)
+	assert.True(t, deps.runtime.createCalled)
+	assert.Equal(t, "cid-1", deps.runtime.startedID)
+	assert.Equal(t, []forwardingRuleCall{
+		{containerId: "cid-1", model: network.ServiceNetworkModel{HostPort: "8080", ContainerPort: "80", Protocol: "tcp"}},
+	}, deps.network.createdForwardingRules)
+}
+
 func TestContainerServiceStopRejectsNonRunningContainer(t *testing.T) {
 	deps := newContainerServiceTestDeps(true)
 	deps.csm.storeInfo("cid-1", csm.ContainerInfo{ContainerId: "cid-1", ContainerName: "web", State: "created"})
@@ -147,6 +165,7 @@ type containerServiceTestDeps struct {
 	ipam    *fakeIpamHandler
 	image   *fakeImageService
 	runtime *fakeRuntimeHandler
+	network *fakeNetworkService
 }
 
 func newContainerServiceTestDeps(imageExists bool) containerServiceTestDeps {
@@ -155,6 +174,7 @@ func newContainerServiceTestDeps(imageExists bool) containerServiceTestDeps {
 	ipamHandler := &fakeIpamHandler{}
 	imageHandler := &fakeImageService{}
 	runtimeHandler := &fakeRuntimeHandler{}
+	networkHandler := &fakeNetworkService{}
 	service := &ContainerService{
 		filesystemHandler:      &fakeFilesystemHandler{},
 		runtimeHandler:         runtimeHandler,
@@ -163,7 +183,7 @@ func newContainerServiceTestDeps(imageExists bool) containerServiceTestDeps {
 		csmHandler:             csmHandler,
 		psmHandler:             &fakePsmHandler{},
 		imageServiceHandler:    imageHandler,
-		networkServiceHandler:  &fakeNetworkService{},
+		networkServiceHandler:  networkHandler,
 		securityProfileService: securityprofile.NewService(),
 	}
 	return containerServiceTestDeps{
@@ -173,6 +193,7 @@ func newContainerServiceTestDeps(imageExists bool) containerServiceTestDeps {
 		ipam:    ipamHandler,
 		image:   imageHandler,
 		runtime: runtimeHandler,
+		network: networkHandler,
 	}
 }
 
@@ -368,6 +389,7 @@ func (f *fakeCsmHandler) GetLogPath(string) (string, error) { return "", nil }
 
 type fakeIpamHandler struct {
 	released []string
+	forwards map[string][]ipam.ForwardInfo
 }
 
 func (f *fakeIpamHandler) Allocate(containerId string, bridge string) (string, error) {
@@ -398,8 +420,10 @@ func (f *fakeIpamHandler) GetInfoByIp(string) (string, string, error) { return "
 func (f *fakeIpamHandler) SetForwardInfo(string, int, int, string) error {
 	return nil
 }
-func (f *fakeIpamHandler) GetForwardInfo(string) ([]ipam.ForwardInfo, error) { return nil, nil }
-func (f *fakeIpamHandler) GetPoolList() ([]ipam.Pool, error)                 { return nil, nil }
+func (f *fakeIpamHandler) GetForwardInfo(containerId string) ([]ipam.ForwardInfo, error) {
+	return append([]ipam.ForwardInfo{}, f.forwards[containerId]...), nil
+}
+func (f *fakeIpamHandler) GetPoolList() ([]ipam.Pool, error) { return nil, nil }
 func (f *fakeIpamHandler) GetNetworkInfoById(string) (string, ipam.Allocation, error) {
 	return "", ipam.Allocation{}, nil
 }
@@ -453,7 +477,15 @@ func (f *fakePsmHandler) IsPodExist(string) bool                      { return f
 func (f *fakePsmHandler) IsPodOwner(string) bool                      { return true }
 func (f *fakePsmHandler) GetPodOwnerPid(string) (int, error)          { return 0, nil }
 
-type fakeNetworkService struct{}
+type forwardingRuleCall struct {
+	containerId string
+	model       network.ServiceNetworkModel
+}
+
+type fakeNetworkService struct {
+	createdForwardingRules []forwardingRuleCall
+	removedForwardingRules []forwardingRuleCall
+}
 
 func (f *fakeNetworkService) CreateNewNetwork(network.ServiceNewNetworkModel) error { return nil }
 func (f *fakeNetworkService) RemoveNetwork(network.ServiceRemoveNetworkModel) error { return nil }
@@ -462,12 +494,14 @@ func (f *fakeNetworkService) CreateMasqueradeRule(string, string) error         
 func (f *fakeNetworkService) InsertInputRule(int, network.InputRuleModel, string) error {
 	return nil
 }
-func (f *fakeNetworkService) CreateForwardingRule(string, network.ServiceNetworkModel) error {
+func (f *fakeNetworkService) CreateForwardingRule(containerId string, model network.ServiceNetworkModel) error {
+	f.createdForwardingRules = append(f.createdForwardingRules, forwardingRuleCall{containerId: containerId, model: model})
 	return nil
 }
 func (f *fakeNetworkService) CreateRedirectDnsTrafficRule(string, string) error { return nil }
 func (f *fakeNetworkService) RemoveRedirectDnsTrafficRule(string, string) error { return nil }
-func (f *fakeNetworkService) RemoveForwardingRule(string, network.ServiceNetworkModel) error {
+func (f *fakeNetworkService) RemoveForwardingRule(containerId string, model network.ServiceNetworkModel) error {
+	f.removedForwardingRules = append(f.removedForwardingRules, forwardingRuleCall{containerId: containerId, model: model})
 	return nil
 }
 

--- a/internal/condenser/core/network/service.go
+++ b/internal/condenser/core/network/service.go
@@ -354,26 +354,19 @@ func (s *NetworkService) getContainerAddress(containerId string) (string, string
 
 func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface string, containerAddr string, portParam ServiceNetworkModel) error {
 	// 1. dnat
-	dnatRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-A", "PREROUTING",
+	dnatRuleParam := []string{
 		"-i", hostInterface,
 		"-p", portParam.Protocol,
 		"--dport", portParam.HostPort,
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatRule := s.commandFactory.Command(dnatRuleCmd[0], dnatRuleCmd[1:]...)
-	if err := dnatRule.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("nat", "PREROUTING", "append", dnatRuleParam); err != nil {
 		return err
 	}
 
 	// 2. dnat for local host traffic from host namespace
-	dnatOutputRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-A", "OUTPUT",
+	dnatOutputRuleParam := []string{
 		"-m", "addrtype",
 		"--dst-type", "LOCAL",
 		"-p", portParam.Protocol,
@@ -381,16 +374,12 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatOutputRule := s.commandFactory.Command(dnatOutputRuleCmd[0], dnatOutputRuleCmd[1:]...)
-	if err := dnatOutputRule.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("nat", "OUTPUT", "append", dnatOutputRuleParam); err != nil {
 		return err
 	}
 
 	// 3. dnat for local host traffic from containers
-	dnatBridgeRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-A", "PREROUTING",
+	dnatBridgeRuleParam := []string{
 		"-i", bridgeInterface,
 		"-m", "addrtype",
 		"--dst-type", "LOCAL",
@@ -399,15 +388,12 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatBridgeRule := s.commandFactory.Command(dnatBridgeRuleCmd[0], dnatBridgeRuleCmd[1:]...)
-	if err := dnatBridgeRule.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("nat", "PREROUTING", "append", dnatBridgeRuleParam); err != nil {
 		return err
 	}
 
 	// 4. allow forward: in
-	forwardInCmd := []string{
-		"iptables",
-		"-A", "FORWARD",
+	forwardInParam := []string{
 		"-i", hostInterface,
 		"-o", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -415,15 +401,12 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 		"-d", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardIn := s.commandFactory.Command(forwardInCmd[0], forwardInCmd[1:]...)
-	if err := forwardIn.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("", "FORWARD", "append", forwardInParam); err != nil {
 		return err
 	}
 
 	// 5. allow forwarded dnat traffic within same bridge (container -> hostAddr -> container)
-	forwardHairpinCmd := []string{
-		"iptables",
-		"-I", "FORWARD", "1",
+	forwardHairpinParam := []string{
 		"-i", bridgeInterface,
 		"-o", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -433,15 +416,12 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 		"-d", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardHairpin := s.commandFactory.Command(forwardHairpinCmd[0], forwardHairpinCmd[1:]...)
-	if err := forwardHairpin.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("", "FORWARD", "insert-first", forwardHairpinParam); err != nil {
 		return err
 	}
 
 	// 6. allow forward: out
-	forwardOutCmd := []string{
-		"iptables",
-		"-A", "FORWARD",
+	forwardOutParam := []string{
 		"-o", hostInterface,
 		"-i", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -449,8 +429,7 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 		"-s", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardOut := s.commandFactory.Command(forwardOutCmd[0], forwardOutCmd[1:]...)
-	if err := forwardOut.Run(); err != nil {
+	if err := s.addIptablesRuleIfMissing("", "FORWARD", "append", forwardOutParam); err != nil {
 		return err
 	}
 
@@ -459,26 +438,19 @@ func (s *NetworkService) setForwardRules(hostInterface string, bridgeInterface s
 
 func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterface string, containerAddr string, portParam ServiceNetworkModel) error {
 	// 1. dnat
-	dnatRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-D", "PREROUTING",
+	dnatRuleParam := []string{
 		"-i", hostInterface,
 		"-p", portParam.Protocol,
 		"--dport", portParam.HostPort,
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatRule := s.commandFactory.Command(dnatRuleCmd[0], dnatRuleCmd[1:]...)
-	if err := dnatRule.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("nat", "PREROUTING", dnatRuleParam); err != nil {
 		return err
 	}
 
 	// 2. dnat for local host traffic from host namespace
-	dnatOutputRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-D", "OUTPUT",
+	dnatOutputRuleParam := []string{
 		"-m", "addrtype",
 		"--dst-type", "LOCAL",
 		"-p", portParam.Protocol,
@@ -486,16 +458,12 @@ func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterfac
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatOutputRule := s.commandFactory.Command(dnatOutputRuleCmd[0], dnatOutputRuleCmd[1:]...)
-	if err := dnatOutputRule.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("nat", "OUTPUT", dnatOutputRuleParam); err != nil {
 		return err
 	}
 
 	// 3. dnat for local host traffic from containers
-	dnatBridgeRuleCmd := []string{
-		"iptables",
-		"-t", "nat",
-		"-D", "PREROUTING",
+	dnatBridgeRuleParam := []string{
 		"-i", bridgeInterface,
 		"-m", "addrtype",
 		"--dst-type", "LOCAL",
@@ -504,15 +472,12 @@ func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterfac
 		"-j", "DNAT",
 		"--to-destination", containerAddr + ":" + portParam.ContainerPort,
 	}
-	dnatBridgeRule := s.commandFactory.Command(dnatBridgeRuleCmd[0], dnatBridgeRuleCmd[1:]...)
-	if err := dnatBridgeRule.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("nat", "PREROUTING", dnatBridgeRuleParam); err != nil {
 		return err
 	}
 
 	// 4. allow forward: in
-	forwardInCmd := []string{
-		"iptables",
-		"-D", "FORWARD",
+	forwardInParam := []string{
 		"-i", hostInterface,
 		"-o", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -520,15 +485,12 @@ func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterfac
 		"-d", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardIn := s.commandFactory.Command(forwardInCmd[0], forwardInCmd[1:]...)
-	if err := forwardIn.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("", "FORWARD", forwardInParam); err != nil {
 		return err
 	}
 
 	// 5. allow forwarded dnat traffic within same bridge (container -> hostAddr -> container)
-	forwardHairpinCmd := []string{
-		"iptables",
-		"-D", "FORWARD",
+	forwardHairpinParam := []string{
 		"-i", bridgeInterface,
 		"-o", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -538,15 +500,12 @@ func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterfac
 		"-d", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardHairpin := s.commandFactory.Command(forwardHairpinCmd[0], forwardHairpinCmd[1:]...)
-	if err := forwardHairpin.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("", "FORWARD", forwardHairpinParam); err != nil {
 		return err
 	}
 
 	// 6. allow forward: out
-	forwardOutCmd := []string{
-		"iptables",
-		"-D", "FORWARD",
+	forwardOutParam := []string{
 		"-o", hostInterface,
 		"-i", bridgeInterface,
 		"-p", portParam.Protocol,
@@ -554,10 +513,58 @@ func (s *NetworkService) deleteForwardRules(hostInterface string, bridgeInterfac
 		"-s", containerAddr,
 		"-j", "ACCEPT",
 	}
-	forwardOut := s.commandFactory.Command(forwardOutCmd[0], forwardOutCmd[1:]...)
-	if err := forwardOut.Run(); err != nil {
+	if err := s.deleteIptablesRuleIfExists("", "FORWARD", forwardOutParam); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func (s *NetworkService) addIptablesRuleIfMissing(table string, chain string, mode string, ruleParam []string) error {
+	checkCmd := buildIptablesRuleCommand(table, "-C", chain, "", ruleParam)
+	check := s.commandFactory.Command(checkCmd[0], checkCmd[1:]...)
+	if err := check.Run(); err == nil {
+		return nil
+	}
+
+	var addCmd []string
+	switch mode {
+	case "insert-first":
+		addCmd = buildIptablesRuleCommand(table, "-I", chain, "1", ruleParam)
+	default:
+		addCmd = buildIptablesRuleCommand(table, "-A", chain, "", ruleParam)
+	}
+	add := s.commandFactory.Command(addCmd[0], addCmd[1:]...)
+	if err := add.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *NetworkService) deleteIptablesRuleIfExists(table string, chain string, ruleParam []string) error {
+	checkCmd := buildIptablesRuleCommand(table, "-C", chain, "", ruleParam)
+	check := s.commandFactory.Command(checkCmd[0], checkCmd[1:]...)
+	if err := check.Run(); err != nil {
+		return nil
+	}
+
+	deleteCmd := buildIptablesRuleCommand(table, "-D", chain, "", ruleParam)
+	deleteRule := s.commandFactory.Command(deleteCmd[0], deleteCmd[1:]...)
+	if err := deleteRule.Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func buildIptablesRuleCommand(table string, op string, chain string, position string, ruleParam []string) []string {
+	cmd := []string{"iptables"}
+	if table != "" {
+		cmd = append(cmd, "-t", table)
+	}
+	cmd = append(cmd, op, chain)
+	if position != "" {
+		cmd = append(cmd, position)
+	}
+	cmd = append(cmd, ruleParam...)
+	return cmd
 }

--- a/internal/condenser/core/network/service_test.go
+++ b/internal/condenser/core/network/service_test.go
@@ -142,6 +142,56 @@ func TestNetworkServiceCreateBridgeRejectsUnmanagedNamespaceBridge(t *testing.T)
 	}, commands.calls)
 }
 
+func TestNetworkServiceCreateForwardingRuleSkipsExistingRules(t *testing.T) {
+	ipamHandler := &fakeNetworkIpamHandler{
+		hostInterface:   "eth0",
+		bridgeInterface: "raind1",
+		containerAddr:   "10.166.1.2",
+	}
+	commands := &fakeNetworkCommandFactory{}
+	service := &NetworkService{commandFactory: commands, ipamHandler: ipamHandler, policyHandler: &fakePolicyService{}}
+
+	err := service.CreateForwardingRule("cid-1", ServiceNetworkModel{HostPort: "8080", ContainerPort: "80", Protocol: "tcp"})
+
+	require.NoError(t, err)
+	assert.Equal(t, []networkCommandCall{
+		{name: "iptables", args: []string{"-t", "nat", "-C", "PREROUTING", "-i", "eth0", "-p", "tcp", "--dport", "8080", "-j", "DNAT", "--to-destination", "10.166.1.2:80"}},
+		{name: "iptables", args: []string{"-t", "nat", "-C", "OUTPUT", "-m", "addrtype", "--dst-type", "LOCAL", "-p", "tcp", "--dport", "8080", "-j", "DNAT", "--to-destination", "10.166.1.2:80"}},
+		{name: "iptables", args: []string{"-t", "nat", "-C", "PREROUTING", "-i", "raind1", "-m", "addrtype", "--dst-type", "LOCAL", "-p", "tcp", "--dport", "8080", "-j", "DNAT", "--to-destination", "10.166.1.2:80"}},
+		{name: "iptables", args: []string{"-C", "FORWARD", "-i", "eth0", "-o", "raind1", "-p", "tcp", "--dport", "8080", "-d", "10.166.1.2", "-j", "ACCEPT"}},
+		{name: "iptables", args: []string{"-C", "FORWARD", "-i", "raind1", "-o", "raind1", "-p", "tcp", "-m", "conntrack", "--ctstate", "DNAT", "--dport", "80", "-d", "10.166.1.2", "-j", "ACCEPT"}},
+		{name: "iptables", args: []string{"-C", "FORWARD", "-o", "eth0", "-i", "raind1", "-p", "tcp", "--sport", "8080", "-s", "10.166.1.2", "-j", "ACCEPT"}},
+	}, commands.calls)
+}
+
+func TestNetworkServiceRemoveForwardingRuleIgnoresMissingRules(t *testing.T) {
+	ipamHandler := &fakeNetworkIpamHandler{
+		hostInterface:   "eth0",
+		bridgeInterface: "raind1",
+		containerAddr:   "10.166.1.2",
+	}
+	commands := &fakeNetworkCommandFactory{
+		runErrors: []error{
+			errors.New("dnat rule not found"),
+			errors.New("output rule not found"),
+			errors.New("bridge rule not found"),
+			errors.New("forward in rule not found"),
+			errors.New("hairpin rule not found"),
+			errors.New("forward out rule not found"),
+		},
+	}
+	service := &NetworkService{commandFactory: commands, ipamHandler: ipamHandler, policyHandler: &fakePolicyService{}}
+
+	err := service.RemoveForwardingRule("cid-1", ServiceNetworkModel{HostPort: "8080", ContainerPort: "80", Protocol: "tcp"})
+
+	require.NoError(t, err)
+	assert.Len(t, commands.calls, 6)
+	for _, call := range commands.calls {
+		assert.Contains(t, call.args, "-C")
+		assert.NotContains(t, call.args, "-D")
+	}
+}
+
 func TestParseLinkNames(t *testing.T) {
 	out := "1: lo: <LOOPBACK>\n2: rns-demo@if10: <BROADCAST>\n3: rd_abc@if2: <BROADCAST>\n"
 
@@ -202,10 +252,13 @@ func (e *fakeNetworkCommandExecutor) SetStderr(io.Writer)            {}
 func (e *fakeNetworkCommandExecutor) SetStdin(io.Reader)             {}
 
 type fakeNetworkIpamHandler struct {
-	storedBridges  []string
-	removedBridges []string
-	networkList    []ipam.NetworkList
-	dnsProxyAddr   string
+	storedBridges   []string
+	removedBridges  []string
+	networkList     []ipam.NetworkList
+	dnsProxyAddr    string
+	hostInterface   string
+	bridgeInterface string
+	containerAddr   string
 }
 
 func (f *fakeNetworkIpamHandler) Allocate(string, string) (string, error) { return "", nil }
@@ -239,7 +292,7 @@ func (f *fakeNetworkIpamHandler) GetDnsProxyInfo() (string, string, []string, er
 	return "raindDns", addr, []string{"8.8.8.8"}, nil
 }
 func (f *fakeNetworkIpamHandler) GetContainerAddress(string) (string, string, string, error) {
-	return "", "", "", nil
+	return f.hostInterface, f.bridgeInterface, f.containerAddr, nil
 }
 func (f *fakeNetworkIpamHandler) GetInfoByIp(string) (string, string, error) {
 	return "", "", nil


### PR DESCRIPTION
## Summary

Restore single-container host port forwarding rules when starting a stopped container.

This change makes container-level forwarding rule operations idempotent and restores persisted IPAM forwarding information during the stopped-to-running container start path.

## Motivation

Fixes #41.

Single containers started with host port publishing, such as `raind container run -p 8080:80 nginx`, install forwarding rules during `run` / `create`.

If the host is rebooted while the container is running, iptables runtime state is lost. After reboot, condenser monitoring correctly detects the missing container process and marks the container as `stopped`. Starting the container again succeeds, but the host port forwarding rules are not restored, so the published port remains unreachable.

Resource-based deployments are less affected because service resources are reconciled separately by the service controller. Single containers need equivalent restoration from persisted IPAM forwarding state.

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [ ] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [ ] Droplet runtime
* [x] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [x] Networking / policy / netflow
* [ ] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [ ] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [x] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR changes container-level iptables forwarding rule handling.

Forwarding rules are now restored from persisted IPAM `ForwardInfo` when a stopped single container is started again. This restores the expected published-port behavior after host reboot, where iptables runtime state was lost but Raind state still contains the container and port mapping metadata.

Forwarding rule create/delete operations are also made idempotent:

* creating an already-existing forwarding rule does not add duplicate iptables entries
* removing an already-missing forwarding rule is treated as successful cleanup

This keeps normal `stop` -> `start` flows from duplicating rules and keeps post-reboot cleanup paths from failing because iptables runtime state was already cleared.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below
