### PR TITLE
fix infra pod controller

### DIFF
--- a/internal/condenser/core/pod/controller.go
+++ b/internal/condenser/core/pod/controller.go
@@ -100,20 +100,25 @@ func (c *PodController) reconcileOnce() error {
 				if p.StoppedByUser {
 					continue
 				}
+
+				// The infra container owns the pod namespaces. If it is stopped or
+				// removed while the pod state is still running, member containers may
+				// keep running but the pod cannot safely reuse the old namespace paths.
+				// Recreate the whole pod from its template instead of only restarting
+				// member containers.
+				infraState, err := c.getPodInfraState(p.PodId)
+				if err != nil {
+					log.Printf("pod controller infra check failed: podId=%s err=%v", p.PodId, err)
+					continue
+				}
+				if infraState != "running" {
+					if err := c.recreatePod(p); err != nil {
+						log.Printf("pod controller recreate failed: podId=%s err=%v", p.PodId, err)
+					}
+					continue
+				}
+
 				if p.State == "degraded" {
-					infraState, err := c.getPodInfraState(p.PodId)
-					if err != nil {
-						log.Printf("pod controller infra check failed: podId=%s err=%v", p.PodId, err)
-						continue
-					}
-					// If infra is not running, namespace continuity is broken.
-					// Recreate pod from template (infra + members) to avoid stale ns path usage.
-					if infraState != "running" {
-						if err := c.recreatePod(p); err != nil {
-							log.Printf("pod controller recreate failed: podId=%s err=%v", p.PodId, err)
-						}
-						continue
-					}
 					// Infra is running, so only recover member containers.
 					if _, err := c.podHandler.Start(p.PodId); err != nil {
 						log.Printf("pod controller start failed: podId=%s err=%v", p.PodId, err)

--- a/internal/condenser/core/pod/controller_test.go
+++ b/internal/condenser/core/pod/controller_test.go
@@ -1,0 +1,219 @@
+package pod
+
+import (
+	"fmt"
+	"testing"
+
+	"raind/internal/condenser/core/container"
+	"raind/internal/condenser/store/psm"
+	"raind/internal/condenser/utils"
+)
+
+func TestPodControllerRecreatesReplicaSetPodWhenInfraIsStopped(t *testing.T) {
+	psmHandler := &fakeControllerPsm{
+		replicaSets: []psm.ReplicaSetInfo{{
+			ReplicaSetId: "rs-1",
+			Spec: psm.ReplicaSetSpec{
+				Name:       "demo-web",
+				Namespace:  "demo",
+				Replicas:   1,
+				TemplateId: "tpl-1",
+			},
+		}},
+		templates: []psm.PodTemplateInfo{{TemplateId: "tpl-1"}},
+		pods: map[string]psm.PodInfo{
+			"pod-1": {
+				PodId:      "pod-1",
+				TemplateId: "tpl-1",
+				Name:       "demo-web-old",
+				Namespace:  "demo",
+				State:      "running",
+			},
+		},
+	}
+	podHandler := &fakeControllerPodService{recreatePodId: "pod-2"}
+	containerHandler := &fakeControllerContainerService{
+		containersByPod: map[string][]container.ContainerState{
+			"pod-1": {
+				{ContainerId: "infra-1", Name: utils.PodInfraContainerNamePrefix + "pod-1", PodId: "pod-1", State: "stopped"},
+				{ContainerId: "member-1", Name: "web", PodId: "pod-1", State: "running"},
+			},
+		},
+	}
+	controller := &PodController{
+		psmHandler:       psmHandler,
+		podHandler:       podHandler,
+		containerHandler: containerHandler,
+	}
+
+	if err := controller.reconcileOnce(); err != nil {
+		t.Fatalf("reconcileOnce returned error: %v", err)
+	}
+
+	if !psmHandler.removedPods["pod-1"] {
+		t.Fatalf("expected stale pod to be removed")
+	}
+	if podHandler.recreatedTemplateId != "tpl-1" {
+		t.Fatalf("expected pod to be recreated from template tpl-1, got %q", podHandler.recreatedTemplateId)
+	}
+	if podHandler.startedPodId != "pod-2" {
+		t.Fatalf("expected recreated pod to be started, got %q", podHandler.startedPodId)
+	}
+	if !containerHandler.stopped["member-1"] || !containerHandler.deleted["member-1"] || !containerHandler.deleted["infra-1"] {
+		t.Fatalf("expected old infra and member containers to be cleaned up")
+	}
+}
+
+type fakeControllerPsm struct {
+	pods        map[string]psm.PodInfo
+	templates   []psm.PodTemplateInfo
+	replicaSets []psm.ReplicaSetInfo
+	deployments []psm.DeploymentInfo
+	removedPods map[string]bool
+}
+
+func (f *fakeControllerPsm) StorePod(psm.StorePodRequest) error                 { return nil }
+func (f *fakeControllerPsm) StorePodTemplate(string, psm.PodTemplateSpec) error { return nil }
+func (f *fakeControllerPsm) GetPodTemplate(string) (psm.PodTemplateInfo, error) {
+	return psm.PodTemplateInfo{}, nil
+}
+func (f *fakeControllerPsm) GetPodTemplateList() ([]psm.PodTemplateInfo, error) {
+	return f.templates, nil
+}
+func (f *fakeControllerPsm) AddContainerToPodTemplate(string, psm.ContainerTemplateSpec) error {
+	return nil
+}
+func (f *fakeControllerPsm) RemovePodTemplate(string) error                   { return nil }
+func (f *fakeControllerPsm) StoreReplicaSet(string, psm.ReplicaSetSpec) error { return nil }
+func (f *fakeControllerPsm) GetReplicaSet(string) (psm.ReplicaSetInfo, error) {
+	return psm.ReplicaSetInfo{}, nil
+}
+func (f *fakeControllerPsm) GetReplicaSetList() ([]psm.ReplicaSetInfo, error) {
+	return f.replicaSets, nil
+}
+func (f *fakeControllerPsm) IsTemplateReferenced(string) (bool, error)        { return true, nil }
+func (f *fakeControllerPsm) UpdateReplicaSetReplicas(string, int) error       { return nil }
+func (f *fakeControllerPsm) RemoveReplicaSet(string) error                    { return nil }
+func (f *fakeControllerPsm) StoreDeployment(string, psm.DeploymentSpec) error { return nil }
+func (f *fakeControllerPsm) GetDeployment(string) (psm.DeploymentInfo, error) {
+	return psm.DeploymentInfo{}, nil
+}
+func (f *fakeControllerPsm) GetDeploymentList() ([]psm.DeploymentInfo, error) {
+	return f.deployments, nil
+}
+func (f *fakeControllerPsm) UpdateDeploymentReplicas(string, int) error      { return nil }
+func (f *fakeControllerPsm) UpdateDeploymentReplicaSet(string, string) error { return nil }
+func (f *fakeControllerPsm) RemoveDeployment(string) error                   { return nil }
+func (f *fakeControllerPsm) RemovePod(podId string) error {
+	if _, ok := f.pods[podId]; !ok {
+		return fmt.Errorf("podId=%s not found", podId)
+	}
+	if f.removedPods == nil {
+		f.removedPods = make(map[string]bool)
+	}
+	f.removedPods[podId] = true
+	delete(f.pods, podId)
+	return nil
+}
+func (f *fakeControllerPsm) UpdatePod(string, string) error            { return nil }
+func (f *fakeControllerPsm) UpdatePodStoppedByUser(string, bool) error { return nil }
+func (f *fakeControllerPsm) UpdatePodNamespaces(int, string, string, string, string, string) error {
+	return nil
+}
+func (f *fakeControllerPsm) ResetPodNamespaces(string) error { return nil }
+func (f *fakeControllerPsm) GetPodList() ([]psm.PodInfo, error) {
+	pods := make([]psm.PodInfo, 0, len(f.pods))
+	for _, p := range f.pods {
+		pods = append(pods, p)
+	}
+	return pods, nil
+}
+func (f *fakeControllerPsm) GetPodById(podId string) (psm.PodInfo, error) {
+	p, ok := f.pods[podId]
+	if !ok {
+		return psm.PodInfo{}, fmt.Errorf("pod: %s not found", podId)
+	}
+	return p, nil
+}
+func (f *fakeControllerPsm) IsNameAlreadyUsed(string, string) bool { return false }
+func (f *fakeControllerPsm) GetPodIdByName(string, string) (string, error) {
+	return "", fmt.Errorf("not found")
+}
+func (f *fakeControllerPsm) ResolvePodId(string, string) (string, error) { return "", nil }
+func (f *fakeControllerPsm) IsPodExist(string) bool                      { return true }
+func (f *fakeControllerPsm) IsPodOwner(string) bool                      { return false }
+func (f *fakeControllerPsm) GetPodOwnerPid(string) (int, error)          { return 0, nil }
+
+type fakeControllerPodService struct {
+	recreatePodId       string
+	recreatedTemplateId string
+	startedPodId        string
+}
+
+func (f *fakeControllerPodService) Create(ServiceCreateModel) (string, error) { return "", nil }
+func (f *fakeControllerPodService) RecreateFromTemplate(templateId string) (string, error) {
+	f.recreatedTemplateId = templateId
+	return f.recreatePodId, nil
+}
+func (f *fakeControllerPodService) CreateFromTemplate(string, string) (string, error) { return "", nil }
+func (f *fakeControllerPodService) Start(podId string) (string, error) {
+	f.startedPodId = podId
+	return podId, nil
+}
+func (f *fakeControllerPodService) Stop(string) (string, error)         { return "", nil }
+func (f *fakeControllerPodService) Remove(string) (string, error)       { return "", nil }
+func (f *fakeControllerPodService) GetPodList() ([]PodState, error)     { return nil, nil }
+func (f *fakeControllerPodService) GetPodById(string) (PodState, error) { return PodState{}, nil }
+
+type fakeControllerContainerService struct {
+	containersByPod map[string][]container.ContainerState
+	stopped         map[string]bool
+	deleted         map[string]bool
+}
+
+func (f *fakeControllerContainerService) Create(container.ServiceCreateModel) (string, error) {
+	return "", nil
+}
+func (f *fakeControllerContainerService) Start(container.ServiceStartModel) (string, error) {
+	return "", nil
+}
+func (f *fakeControllerContainerService) Delete(param container.ServiceDeleteModel) (string, error) {
+	if f.deleted == nil {
+		f.deleted = make(map[string]bool)
+	}
+	f.deleted[param.ContainerId] = true
+	return param.ContainerId, nil
+}
+func (f *fakeControllerContainerService) Stop(param container.ServiceStopModel) (string, error) {
+	if f.stopped == nil {
+		f.stopped = make(map[string]bool)
+	}
+	f.stopped[param.ContainerId] = true
+	return param.ContainerId, nil
+}
+func (f *fakeControllerContainerService) Exec(container.ServiceExecModel) error { return nil }
+func (f *fakeControllerContainerService) GetContainerList() ([]container.ContainerState, error) {
+	return nil, nil
+}
+func (f *fakeControllerContainerService) GetContainerById(string) (container.ContainerState, error) {
+	return container.ContainerState{}, nil
+}
+func (f *fakeControllerContainerService) GetContainerStats(string) (container.ContainerStats, error) {
+	return container.ContainerStats{}, nil
+}
+func (f *fakeControllerContainerService) ListContainerStats() ([]container.ContainerStats, error) {
+	return nil, nil
+}
+func (f *fakeControllerContainerService) GetContainersByPodId(podId string) ([]container.ContainerState, error) {
+	return f.containersByPod[podId], nil
+}
+func (f *fakeControllerContainerService) GetContainerLogPath(string) (string, error) { return "", nil }
+func (f *fakeControllerContainerService) GetContainerSpec(string) (map[string]any, error) {
+	return nil, nil
+}
+func (f *fakeControllerContainerService) InspectContainer(string) (container.ContainerInspect, error) {
+	return container.ContainerInspect{}, nil
+}
+func (f *fakeControllerContainerService) GetLogWithTailLines(string, int) ([]byte, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary

Fix reconciliation for ReplicaSet/Deployment-managed pods when their infra container is stopped or removed.

Previously, if only the infra container was stopped or deleted while member/application containers were still running, the pod could continue to be reported as ready and no recovery was triggered. This PR updates the controller behavior so that infra container health is checked during reconciliation, and an unhealthy or missing infra container causes the pod to be recreated from the owning ReplicaSet template.

## Motivation
Fixes: #47 

The infra container owns the pod namespace, so losing it means the pod should no longer be considered healthy.

Application/member container failures were already reconciled correctly: readiness temporarily dropped and then recovered. However, infra container failures did not trigger the same recovery path, which allowed Deployment status to continue reporting all replicas as ready even though one pod had lost its infra container.

This change ensures that ReplicaSet/Deployment-managed pods are restored to the desired state when their infra container is stopped or removed.

Fixes: #<!-- issue number -->

## Type of change

* [x] Bug fix
* [ ] Feature
* [ ] Documentation
* [ ] Refactoring
* [x] Test improvement
* [ ] Build / CI / packaging
* [ ] Security hardening

## Affected areas

* [ ] CLI
* [x] Condenser API / controller
* [ ] Droplet runtime
* [x] Container lifecycle
* [ ] Container exec / exec-shim
* [ ] Rootless containers
* [ ] Image handling
* [ ] Networking / policy / netflow
* [x] Kubernetes-style resources
* [ ] Snap / packaging
* [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

* [x] namespaces
* [ ] mount / rootfs / pivot_root
* [ ] cgroups
* [ ] capabilities
* [ ] seccomp
* [ ] AppArmor
* [ ] rootless UID/GID mappings
* [ ] certificate / API authentication
* [x] network namespace / iptables / nftables
* [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR changes controller reconciliation behavior for pods whose infra container is stopped or removed. The infra container owns the pod namespace, including namespace-related runtime state used by member containers. When the infra container is unhealthy or missing, the pod is now treated as unhealthy and recreated from the ReplicaSet template.

This does not intentionally change namespace isolation, permissions, capabilities, seccomp, AppArmor, rootless mappings, authentication, or user-controlled mount behavior. The expected security behavior is that pods are restored by recreating their infra and member containers using the existing pod creation path and existing runtime security settings.

## Documentation

* [ ] Documentation updated
* [x] Documentation not needed

## Compatibility / breaking changes

* [x] No breaking changes
* [ ] Possible breaking changes described below

This change only updates controller reconciliation behavior for unhealthy ReplicaSet/Deployment-managed pods. No CLI, API, manifest, or configuration compatibility changes are expected.
