### PR TITLE
fix service rule cleanup

### DIFF
--- a/internal/condenser/core/service/controller.go
+++ b/internal/condenser/core/service/controller.go
@@ -68,8 +68,8 @@ func (c *ServiceController) reconcileOnce() error {
 			}
 			stateKey := c.buildStateKey(svc, endpoints)
 			if prev := c.lastState[svc.ServiceId]; prev != stateKey {
-				if prevSvc, ok := c.lastState[svc.ServiceId]; ok {
-					c.cleanupService(prevSvc)
+				if _, ok := c.lastState[svc.ServiceId]; ok {
+					c.cleanupService(svc.ServiceId)
 				}
 				c.lastState[svc.ServiceId] = stateKey
 				c.lastServices[svc.ServiceId] = svc

--- a/internal/condenser/core/service/controller_test.go
+++ b/internal/condenser/core/service/controller_test.go
@@ -2,9 +2,11 @@ package service
 
 import (
 	"io"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"raind/internal/condenser/store/psm"
 	"raind/internal/condenser/store/ssm"
 	"raind/internal/condenser/utils"
 
@@ -43,6 +45,55 @@ func TestAddClusterIPJumpRuleUsesClusterIPDestination(t *testing.T) {
 	require.Len(t, commands.commands, 2)
 	assert.Contains(t, commands.commands[0], "-A PREROUTING -d 10.166.255.1/32 -p tcp --dport 80 -j RAIND-SVC-abc-80")
 	assert.Contains(t, commands.commands[1], "-A OUTPUT -d 10.166.255.1/32 -p tcp --dport 80 -j RAIND-SVC-abc-80")
+}
+
+func TestReconcileCleansPreviousServiceRulesByServiceID(t *testing.T) {
+	dir := t.TempDir()
+	ssmHandler := ssm.NewSsmManager(ssm.NewSsmStore(filepath.Join(dir, "ssm.json")))
+	psmHandler := psm.NewPsmManager(psm.NewPsmStore(filepath.Join(dir, "psm.json")))
+	commands := &recordedCommandFactory{}
+
+	oldSvc := ssm.ServiceInfo{
+		ServiceId: "svc-1",
+		Name:      "web",
+		Namespace: "default",
+		Type:      ssm.ServiceTypeNodePort,
+		Ports: []ssm.ServicePort{{
+			Port:       80,
+			TargetPort: 80,
+			Protocol:   "tcp",
+		}},
+	}
+	newSvc := ssm.ServiceInfo{
+		Name:      "web",
+		Namespace: "default",
+		Type:      ssm.ServiceTypeNodePort,
+		Ports: []ssm.ServicePort{{
+			Port:       8080,
+			TargetPort: 80,
+			Protocol:   "tcp",
+		}},
+	}
+	require.NoError(t, ssmHandler.StoreService("svc-1", newSvc))
+
+	controller := &ServiceController{
+		psmHandler:     psmHandler,
+		ssmHandler:     ssmHandler,
+		commandFactory: commands,
+		lastState: map[string]string{
+			"svc-1": "old-state",
+		},
+		lastServices: map[string]ssm.ServiceInfo{
+			"svc-1": oldSvc,
+		},
+	}
+
+	require.NoError(t, controller.reconcileOnce())
+
+	assert.Contains(t, commands.commands, "iptables -t nat -D PREROUTING -p tcp --dport 80 -j RAIND-SVC-svc-1-80")
+	assert.Contains(t, commands.commands, "iptables -t nat -D OUTPUT -m addrtype --dst-type LOCAL -p tcp --dport 80 -j RAIND-SVC-svc-1-80")
+	assert.Contains(t, commands.commands, "iptables -t nat -F RAIND-SVC-svc-1-80")
+	assert.Contains(t, commands.commands, "iptables -t nat -X RAIND-SVC-svc-1-80")
 }
 
 func TestServiceTypeDefaultsToClusterIP(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix ServiceController cleanup during service state changes so stale rules are removed using the service ID instead of the previous state key.

This PR also adds a regression test that verifies old NodePort NAT rules are deleted when a Service changes ports.

## Motivation

Fixes: #49 

ServiceController stores a computed state key in `lastState[serviceId]`, but the reconcile path used that value as the argument to `cleanupService()`. Since `cleanupService()` expects a service ID and looks up `lastServices[serviceId]`, cleanup could become a no-op when endpoints, ports, ClusterIP, or NodePort state changed.

This could leave stale iptables/NAT rules behind after Service reconciliation.

Related issue:

- `workspace/raind-controller-stability-issues/01-bug-service-rule-cleanup-uses-state-key.md`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring
- [x] Test improvement
- [ ] Build / CI / packaging
- [ ] Security hardening

## Affected areas

- [ ] CLI
- [x] Condenser API / controller
- [ ] Droplet runtime
- [ ] Container lifecycle
- [ ] Container exec / exec-shim
- [ ] Rootless containers
- [ ] Image handling
- [x] Networking / policy / netflow
- [x] Kubernetes-style resources
- [ ] Snap / packaging
- [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

- [ ] namespaces
- [ ] mount / rootfs / pivot_root
- [ ] cgroups
- [ ] capabilities
- [ ] seccomp
- [ ] AppArmor
- [ ] rootless UID/GID mappings
- [ ] certificate / API authentication
- [x] network namespace / iptables / nftables
- [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This change affects iptables cleanup for Raind Services. It does not broaden access or add new forwarding behavior. Expected behavior is that stale NAT rules from the previous Service state are removed before the updated Service rules are installed.

## Testing

Commands run:

```sh
workshop run -- test-unit
workshop run -- test-e2e
```

Results:

- `test-unit` passed.
- `test-e2e` passed.

## Documentation

- [ ] Documentation updated
- [x] Documentation not needed

## Compatibility / breaking changes

- [x] No breaking changes
- [ ] Possible breaking changes described below

