### PR TITLE
fix cleanup forward rule

### DIFF
--- a/internal/condenser/core/service/controller.go
+++ b/internal/condenser/core/service/controller.go
@@ -175,6 +175,18 @@ func (c *ServiceController) buildStateKey(svc ssm.ServiceInfo, endpoints []svcEn
 }
 
 func (c *ServiceController) applyRules(svc ssm.ServiceInfo, endpoints []svcEndpoint) error {
+	forwardChain := c.serviceForwardChainName(svc.ServiceId)
+	if err := c.ensureForwardChain(forwardChain); err != nil {
+		return err
+	}
+	if err := c.flushForwardChain(forwardChain); err != nil {
+		return err
+	}
+	_ = c.deleteForwardJumpRule(forwardChain)
+	if err := c.addForwardJumpRule(forwardChain); err != nil {
+		return err
+	}
+
 	for _, port := range svc.Ports {
 		if port.Port == 0 || port.TargetPort == 0 {
 			continue
@@ -208,7 +220,7 @@ func (c *ServiceController) applyRules(svc ssm.ServiceInfo, endpoints []svcEndpo
 					return err
 				}
 			}
-			_ = c.addForwardRules(ep, port.TargetPort, proto)
+			_ = c.addForwardRules(forwardChain, ep, port.TargetPort, proto)
 		}
 	}
 	return nil
@@ -240,6 +252,14 @@ func (c *ServiceController) serviceChainName(serviceId string, port int) string 
 	return "RAIND-SVC-" + id + "-" + itoa(port)
 }
 
+func (c *ServiceController) serviceForwardChainName(serviceId string) string {
+	id := serviceId
+	if len(id) > 8 {
+		id = id[:8]
+	}
+	return "RAIND-FWD-" + id
+}
+
 func (c *ServiceController) serviceExists(serviceId string, list []ssm.ServiceInfo) bool {
 	for _, s := range list {
 		if s.ServiceId == serviceId {
@@ -258,6 +278,11 @@ func (c *ServiceController) cleanupService(serviceId string) {
 }
 
 func (c *ServiceController) cleanupServiceRules(svc ssm.ServiceInfo) {
+	forwardChain := c.serviceForwardChainName(svc.ServiceId)
+	_ = c.deleteForwardJumpRule(forwardChain)
+	_ = c.flushForwardChain(forwardChain)
+	_ = c.deleteForwardChain(forwardChain)
+
 	for _, p := range svc.Ports {
 		if p.Port == 0 {
 			continue
@@ -284,6 +309,33 @@ func (c *ServiceController) ensureChain(chain string) error {
 func (c *ServiceController) flushChain(chain string) error {
 	cmd := c.commandFactory.Command("iptables", "-t", "nat", "-F", chain)
 	return cmd.Run()
+}
+
+func (c *ServiceController) ensureForwardChain(chain string) error {
+	cmd := c.commandFactory.Command("iptables", "-N", chain)
+	_ = cmd.Run()
+	return nil
+}
+
+func (c *ServiceController) flushForwardChain(chain string) error {
+	cmd := c.commandFactory.Command("iptables", "-F", chain)
+	return cmd.Run()
+}
+
+func (c *ServiceController) deleteForwardChain(chain string) error {
+	cmd := c.commandFactory.Command("iptables", "-X", chain)
+	return cmd.Run()
+}
+
+func (c *ServiceController) addForwardJumpRule(chain string) error {
+	cmd := c.commandFactory.Command("iptables", "-I", "FORWARD", "1", "-j", chain)
+	return cmd.Run()
+}
+
+func (c *ServiceController) deleteForwardJumpRule(chain string) error {
+	cmd := c.commandFactory.Command("iptables", "-D", "FORWARD", "-j", chain)
+	_ = cmd.Run()
+	return nil
 }
 
 func (c *ServiceController) deleteNodePortJumpRule(chain, proto string, port int) error {
@@ -376,12 +428,12 @@ func (c *ServiceController) addEndpointRule(chain, addr string, targetPort int, 
 	return cmd.Run()
 }
 
-func (c *ServiceController) addForwardRules(ep svcEndpoint, targetPort int, proto string) error {
+func (c *ServiceController) addForwardRules(chain string, ep svcEndpoint, targetPort int, proto string) error {
 	if ep.HostInterface == "" || ep.Bridge == "" {
 		return nil
 	}
 	hairpinCmd := []string{
-		"-I", "FORWARD", "1",
+		"-A", chain,
 		"-i", ep.Bridge,
 		"-o", ep.Bridge,
 		"-p", proto,
@@ -394,7 +446,7 @@ func (c *ServiceController) addForwardRules(ep svcEndpoint, targetPort int, prot
 	_ = c.commandFactory.Command("iptables", hairpinCmd...).Run()
 
 	inCmd := []string{
-		"-A", "FORWARD",
+		"-A", chain,
 		"-i", ep.HostInterface,
 		"-o", ep.Bridge,
 		"-p", proto,
@@ -405,7 +457,7 @@ func (c *ServiceController) addForwardRules(ep svcEndpoint, targetPort int, prot
 	_ = c.commandFactory.Command("iptables", inCmd...).Run()
 
 	outCmd := []string{
-		"-A", "FORWARD",
+		"-A", chain,
 		"-o", ep.HostInterface,
 		"-i", ep.Bridge,
 		"-p", proto,

--- a/internal/condenser/core/service/controller_test.go
+++ b/internal/condenser/core/service/controller_test.go
@@ -94,6 +94,42 @@ func TestReconcileCleansPreviousServiceRulesByServiceID(t *testing.T) {
 	assert.Contains(t, commands.commands, "iptables -t nat -D OUTPUT -m addrtype --dst-type LOCAL -p tcp --dport 80 -j RAIND-SVC-svc-1-80")
 	assert.Contains(t, commands.commands, "iptables -t nat -F RAIND-SVC-svc-1-80")
 	assert.Contains(t, commands.commands, "iptables -t nat -X RAIND-SVC-svc-1-80")
+	assert.Contains(t, commands.commands, "iptables -D FORWARD -j RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -F RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -X RAIND-FWD-svc-1")
+}
+
+func TestApplyRulesUsesManagedForwardChain(t *testing.T) {
+	commands := &recordedCommandFactory{}
+	controller := &ServiceController{commandFactory: commands}
+	svc := ssm.ServiceInfo{
+		ServiceId: "svc-1",
+		Name:      "web",
+		Namespace: "default",
+		Type:      ssm.ServiceTypeNodePort,
+		Ports: []ssm.ServicePort{{
+			Port:       8080,
+			TargetPort: 80,
+			Protocol:   "tcp",
+		}},
+	}
+	endpoints := []svcEndpoint{{
+		Addr:          "10.166.0.2",
+		HostInterface: "eth0",
+		Bridge:        "rbr0",
+	}}
+
+	require.NoError(t, controller.applyRules(svc, endpoints))
+
+	assert.Contains(t, commands.commands, "iptables -N RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -F RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -D FORWARD -j RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -I FORWARD 1 -j RAIND-FWD-svc-1")
+	assert.Contains(t, commands.commands, "iptables -A RAIND-FWD-svc-1 -i rbr0 -o rbr0 -p tcp -m conntrack --ctstate DNAT --dport 80 -d 10.166.0.2 -j ACCEPT")
+	assert.Contains(t, commands.commands, "iptables -A RAIND-FWD-svc-1 -i eth0 -o rbr0 -p tcp --dport 80 -d 10.166.0.2 -j ACCEPT")
+	assert.Contains(t, commands.commands, "iptables -A RAIND-FWD-svc-1 -o eth0 -i rbr0 -p tcp --sport 80 -s 10.166.0.2 -j ACCEPT")
+	assert.NotContains(t, commands.commands, "iptables -A FORWARD -i eth0 -o rbr0 -p tcp --dport 80 -d 10.166.0.2 -j ACCEPT")
+	assert.NotContains(t, commands.commands, "iptables -A FORWARD -o eth0 -i rbr0 -p tcp --sport 80 -s 10.166.0.2 -j ACCEPT")
 }
 
 func TestServiceTypeDefaultsToClusterIP(t *testing.T) {


### PR DESCRIPTION
## Summary

Move Service endpoint FORWARD rules into a per-Service managed filter chain to prevent stale rules from accumulating across endpoint changes.

This PR creates a `RAIND-FWD-<service>` chain for each Service, keeps a single jump from `FORWARD` to that chain, and flushes/rebuilds the managed chain during Service reconciliation.

## Motivation

Fixes: #55 

Service reconciliation previously appended endpoint-specific rules directly to the `FORWARD` chain. Cleanup focused on NAT chains and Service jump rules, so repeated endpoint changes could leave stale FORWARD rules behind.

Keeping endpoint rules inside a dedicated Service chain makes reconciliation deterministic:

- `FORWARD` only needs one jump per Service.
- Endpoint rules are rebuilt inside the managed chain.
- Service cleanup can remove the jump and delete the managed chain.

Related issue:

- `workspace/raind-controller-stability-issues/07-bug-service-forward-rules-can-accumulate.md`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring
- [x] Test improvement
- [ ] Build / CI / packaging
- [ ] Security hardening

## Affected areas

- [ ] CLI
- [x] Condenser API / controller
- [ ] Droplet runtime
- [ ] Container lifecycle
- [ ] Container exec / exec-shim
- [ ] Rootless containers
- [ ] Image handling
- [x] Networking / policy / netflow
- [x] Kubernetes-style resources
- [ ] Snap / packaging
- [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

- [ ] namespaces
- [ ] mount / rootfs / pivot_root
- [ ] cgroups
- [ ] capabilities
- [ ] seccomp
- [ ] AppArmor
- [ ] rootless UID/GID mappings
- [ ] certificate / API authentication
- [x] network namespace / iptables / nftables
- [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This change affects filter table rule management for Raind Services. It does not add new traffic permissions beyond the existing endpoint forwarding behavior. Expected behavior is that current Service endpoint forwarding rules are present in the managed chain, while stale endpoint rules are removed when the Service changes or is deleted.

## Testing

Commands run:

```sh
workshop run -- test-unit
workshop run -- dev-cleanup && workshop run -- test-e2e
```

Results:

- `test-unit` passed.
- `test-e2e` passed after resetting the Workshop runtime state with `dev-cleanup`.

## Documentation

- [ ] Documentation updated
- [x] Documentation not needed

## Compatibility / breaking changes

- [x] No breaking changes
- [ ] Possible breaking changes described below

