### PR TITLE
fix service endpoint pod

### DIFF
--- a/internal/condenser/core/service/controller.go
+++ b/internal/condenser/core/service/controller.go
@@ -108,8 +108,8 @@ func (c *ServiceController) buildEndpoints(svc ssm.ServiceInfo, pods []psm.PodIn
 		if !labelsMatch(svc.Selector, p.Labels) {
 			continue
 		}
-		infraId, err := c.getInfraContainerId(p.PodId)
-		if err != nil {
+		infraId, ok := c.getReadyInfraContainerId(p)
+		if !ok {
 			continue
 		}
 		host, bridge, addr, err := c.ipamHandler.GetContainerAddress(infraId)
@@ -126,6 +126,79 @@ func (c *ServiceController) buildEndpoints(svc ssm.ServiceInfo, pods []psm.PodIn
 		return endpoints[i].Addr < endpoints[j].Addr
 	})
 	return endpoints, nil
+}
+
+func (c *ServiceController) getReadyInfraContainerId(p psm.PodInfo) (string, bool) {
+	if p.State != "running" || p.StoppedByUser {
+		return "", false
+	}
+
+	containers, err := c.containerHandler.GetContainersByPodId(p.PodId)
+	if err != nil {
+		return "", false
+	}
+	if len(containers) == 0 {
+		return "", false
+	}
+
+	var (
+		infraId       string
+		runningByName = map[string]struct{}{}
+		memberCount   int
+	)
+	for _, cinfo := range containers {
+		if strings.HasPrefix(cinfo.Name, utils.PodInfraContainerNamePrefix) {
+			if cinfo.State != "running" {
+				return "", false
+			}
+			infraId = cinfo.ContainerId
+			continue
+		}
+		memberCount++
+		if cinfo.State != "running" {
+			return "", false
+		}
+		runningByName[cinfo.Name] = struct{}{}
+	}
+	if infraId == "" || memberCount == 0 {
+		return "", false
+	}
+	if !c.expectedMembersRunning(p, runningByName) {
+		return "", false
+	}
+	return infraId, true
+}
+
+func (c *ServiceController) expectedMembersRunning(p psm.PodInfo, runningByName map[string]struct{}) bool {
+	if p.TemplateId == "" {
+		return true
+	}
+	tpl, err := c.psmHandler.GetPodTemplate(p.TemplateId)
+	if err != nil {
+		return false
+	}
+
+	for _, spec := range tpl.Spec.Containers {
+		if spec.Name == "" {
+			continue
+		}
+		expectedName := buildPodMemberName(spec.Name, p.PodId)
+		if _, ok := runningByName[expectedName]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func buildPodMemberName(baseName, podId string) string {
+	if baseName == "" {
+		return baseName
+	}
+	suffix := podId
+	if len(suffix) > 8 {
+		suffix = suffix[len(suffix)-8:]
+	}
+	return baseName + "-" + suffix
 }
 
 func (c *ServiceController) getInfraContainerId(podId string) (string, error) {

--- a/internal/condenser/core/service/controller_test.go
+++ b/internal/condenser/core/service/controller_test.go
@@ -1,11 +1,14 @@
 package service
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"raind/internal/condenser/core/container"
+	"raind/internal/condenser/store/ipam"
 	"raind/internal/condenser/store/psm"
 	"raind/internal/condenser/store/ssm"
 	"raind/internal/condenser/utils"
@@ -36,6 +39,87 @@ func (n *noopCommandExecutor) SetStdout(w io.Writer)          {}
 func (n *noopCommandExecutor) SetStderr(w io.Writer)          {}
 func (n *noopCommandExecutor) SetStdin(r io.Reader)           {}
 
+type fakeEndpointContainerService struct {
+	containersByPod map[string][]container.ContainerState
+}
+
+func (f *fakeEndpointContainerService) Create(container.ServiceCreateModel) (string, error) {
+	return "", nil
+}
+func (f *fakeEndpointContainerService) Start(container.ServiceStartModel) (string, error) {
+	return "", nil
+}
+func (f *fakeEndpointContainerService) Delete(container.ServiceDeleteModel) (string, error) {
+	return "", nil
+}
+func (f *fakeEndpointContainerService) Stop(container.ServiceStopModel) (string, error) {
+	return "", nil
+}
+func (f *fakeEndpointContainerService) Exec(container.ServiceExecModel) error { return nil }
+func (f *fakeEndpointContainerService) GetContainerList() ([]container.ContainerState, error) {
+	return nil, nil
+}
+func (f *fakeEndpointContainerService) GetContainerById(string) (container.ContainerState, error) {
+	return container.ContainerState{}, nil
+}
+func (f *fakeEndpointContainerService) GetContainerStats(string) (container.ContainerStats, error) {
+	return container.ContainerStats{}, nil
+}
+func (f *fakeEndpointContainerService) ListContainerStats() ([]container.ContainerStats, error) {
+	return nil, nil
+}
+func (f *fakeEndpointContainerService) GetContainersByPodId(podId string) ([]container.ContainerState, error) {
+	return f.containersByPod[podId], nil
+}
+func (f *fakeEndpointContainerService) GetContainerLogPath(string) (string, error) {
+	return "", nil
+}
+func (f *fakeEndpointContainerService) GetContainerSpec(string) (map[string]any, error) {
+	return nil, nil
+}
+func (f *fakeEndpointContainerService) InspectContainer(string) (container.ContainerInspect, error) {
+	return container.ContainerInspect{}, nil
+}
+func (f *fakeEndpointContainerService) GetLogWithTailLines(string, int) ([]byte, error) {
+	return nil, nil
+}
+
+type fakeEndpointIpam struct {
+	addresses map[string]struct {
+		host   string
+		bridge string
+		addr   string
+	}
+}
+
+func (f *fakeEndpointIpam) Allocate(string, string) (string, error)     { return "", nil }
+func (f *fakeEndpointIpam) Release(string) error                        { return nil }
+func (f *fakeEndpointIpam) GetNetworkList() ([]ipam.NetworkList, error) { return nil, nil }
+func (f *fakeEndpointIpam) StoreBridge(string) (string, string, error)  { return "", "", nil }
+func (f *fakeEndpointIpam) RemoveBridge(string) error                   { return nil }
+func (f *fakeEndpointIpam) GetRuntimeSubnet() (string, error)           { return "", nil }
+func (f *fakeEndpointIpam) GetDefaultInterface() (string, error)        { return "", nil }
+func (f *fakeEndpointIpam) GetDefaultInterfaceAddr() (string, error)    { return "", nil }
+func (f *fakeEndpointIpam) GetBridgeAddr(string) (string, error)        { return "", nil }
+func (f *fakeEndpointIpam) GetDnsProxyInfo() (string, string, []string, error) {
+	return "", "", nil, nil
+}
+func (f *fakeEndpointIpam) GetContainerAddress(containerId string) (string, string, string, error) {
+	info, ok := f.addresses[containerId]
+	if !ok {
+		return "", "", "", fmt.Errorf("container address not found: %s", containerId)
+	}
+	return info.host, info.bridge, info.addr, nil
+}
+func (f *fakeEndpointIpam) GetInfoByIp(string) (string, string, error)        { return "", "", nil }
+func (f *fakeEndpointIpam) SetForwardInfo(string, int, int, string) error     { return nil }
+func (f *fakeEndpointIpam) GetForwardInfo(string) ([]ipam.ForwardInfo, error) { return nil, nil }
+func (f *fakeEndpointIpam) GetPoolList() ([]ipam.Pool, error)                 { return nil, nil }
+func (f *fakeEndpointIpam) GetNetworkInfoById(string) (string, ipam.Allocation, error) {
+	return "", ipam.Allocation{}, nil
+}
+func (f *fakeEndpointIpam) GetVethById(string) (string, error) { return "", nil }
+
 func TestAddClusterIPJumpRuleUsesClusterIPDestination(t *testing.T) {
 	commands := &recordedCommandFactory{}
 	controller := &ServiceController{commandFactory: commands}
@@ -45,6 +129,74 @@ func TestAddClusterIPJumpRuleUsesClusterIPDestination(t *testing.T) {
 	require.Len(t, commands.commands, 2)
 	assert.Contains(t, commands.commands[0], "-A PREROUTING -d 10.166.255.1/32 -p tcp --dport 80 -j RAIND-SVC-abc-80")
 	assert.Contains(t, commands.commands[1], "-A OUTPUT -d 10.166.255.1/32 -p tcp --dport 80 -j RAIND-SVC-abc-80")
+}
+
+func TestBuildEndpointsOnlyIncludesReadyPods(t *testing.T) {
+	dir := t.TempDir()
+	psmHandler := psm.NewPsmManager(psm.NewPsmStore(filepath.Join(dir, "psm.json")))
+	require.NoError(t, psmHandler.StorePodTemplate("tpl-1", psm.PodTemplateSpec{
+		Containers: []psm.ContainerTemplateSpec{{Name: "web", Image: "nginx:latest"}},
+	}))
+
+	controller := &ServiceController{
+		psmHandler: psmHandler,
+		containerHandler: &fakeEndpointContainerService{
+			containersByPod: map[string][]container.ContainerState{
+				"pod-ready": {
+					{ContainerId: "infra-ready", Name: utils.PodInfraContainerNamePrefix + "pod-ready", State: "running"},
+					{ContainerId: "member-ready", Name: buildPodMemberName("web", "pod-ready"), State: "running"},
+				},
+				"pod-degraded": {
+					{ContainerId: "infra-degraded", Name: utils.PodInfraContainerNamePrefix + "pod-degraded", State: "running"},
+					{ContainerId: "member-degraded", Name: buildPodMemberName("web", "pod-degraded"), State: "running"},
+				},
+				"pod-stopped-by-user": {
+					{ContainerId: "infra-stopped-by-user", Name: utils.PodInfraContainerNamePrefix + "pod-stopped-by-user", State: "running"},
+					{ContainerId: "member-stopped-by-user", Name: buildPodMemberName("web", "pod-stopped-by-user"), State: "running"},
+				},
+				"pod-infra-stopped": {
+					{ContainerId: "infra-stopped", Name: utils.PodInfraContainerNamePrefix + "pod-infra-stopped", State: "stopped"},
+					{ContainerId: "member-infra-stopped", Name: buildPodMemberName("web", "pod-infra-stopped"), State: "running"},
+				},
+				"pod-member-stopped": {
+					{ContainerId: "infra-member-stopped", Name: utils.PodInfraContainerNamePrefix + "pod-member-stopped", State: "running"},
+					{ContainerId: "member-stopped", Name: buildPodMemberName("web", "pod-member-stopped"), State: "stopped"},
+				},
+				"pod-member-missing": {
+					{ContainerId: "infra-member-missing", Name: utils.PodInfraContainerNamePrefix + "pod-member-missing", State: "running"},
+				},
+			},
+		},
+		ipamHandler: &fakeEndpointIpam{
+			addresses: map[string]struct {
+				host   string
+				bridge string
+				addr   string
+			}{
+				"infra-ready": {host: "eth0", bridge: "rbr0", addr: "10.166.0.2"},
+			},
+		},
+	}
+	svc := ssm.ServiceInfo{
+		Namespace: "default",
+		Selector:  map[string]string{"app": "web"},
+	}
+	pods := []psm.PodInfo{
+		{PodId: "pod-ready", TemplateId: "tpl-1", Namespace: "default", State: "running", Labels: map[string]string{"app": "web"}},
+		{PodId: "pod-degraded", TemplateId: "tpl-1", Namespace: "default", State: "degraded", Labels: map[string]string{"app": "web"}},
+		{PodId: "pod-stopped-by-user", TemplateId: "tpl-1", Namespace: "default", State: "running", StoppedByUser: true, Labels: map[string]string{"app": "web"}},
+		{PodId: "pod-infra-stopped", TemplateId: "tpl-1", Namespace: "default", State: "running", Labels: map[string]string{"app": "web"}},
+		{PodId: "pod-member-stopped", TemplateId: "tpl-1", Namespace: "default", State: "running", Labels: map[string]string{"app": "web"}},
+		{PodId: "pod-member-missing", TemplateId: "tpl-1", Namespace: "default", State: "running", Labels: map[string]string{"app": "web"}},
+	}
+
+	endpoints, err := controller.buildEndpoints(svc, pods)
+
+	require.NoError(t, err)
+	require.Len(t, endpoints, 1)
+	assert.Equal(t, "10.166.0.2", endpoints[0].Addr)
+	assert.Equal(t, "eth0", endpoints[0].HostInterface)
+	assert.Equal(t, "rbr0", endpoints[0].Bridge)
 }
 
 func TestReconcileCleansPreviousServiceRulesByServiceID(t *testing.T) {


### PR DESCRIPTION
## Summary

Filter Service endpoints so only ready Pods are used as Service backends.

This PR updates ServiceController endpoint construction to exclude Pods that are stopped, degraded, user-stopped, missing a running infra container, missing member containers, or have non-running member containers.

## Motivation

Fixes: #50 

Service endpoints were previously selected from namespace, label selector, and infra container IP address only. A Pod could remain in a Service backend set even when its application container was stopped or the Pod state had dropped to `degraded`.

That could route traffic to unhealthy backends while Deployment readiness was already reporting reduced availability.

Related issue:

- `workspace/raind-controller-stability-issues/02-bug-service-endpoints-include-unhealthy-pods.md`

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring
- [x] Test improvement
- [ ] Build / CI / packaging
- [ ] Security hardening

## Affected areas

- [ ] CLI
- [x] Condenser API / controller
- [ ] Droplet runtime
- [ ] Container lifecycle
- [ ] Container exec / exec-shim
- [ ] Rootless containers
- [ ] Image handling
- [x] Networking / policy / netflow
- [x] Kubernetes-style resources
- [ ] Snap / packaging
- [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

- [ ] namespaces
- [ ] mount / rootfs / pivot_root
- [ ] cgroups
- [ ] capabilities
- [ ] seccomp
- [ ] AppArmor
- [ ] rootless UID/GID mappings
- [ ] certificate / API authentication
- [x] network namespace / iptables / nftables
- [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This change affects which Pod IPs are installed as Service backend rules. It does not add new traffic permissions. Expected behavior is that only ready Pods receive Service traffic, and unhealthy Pods are removed from the desired backend set during reconciliation.

## Testing

Commands run:

```sh
workshop run -- test-unit
workshop run -- dev-cleanup && workshop run -- test-e2e
```

Results:

- `test-unit` passed.
- `test-e2e` passed after resetting the Workshop runtime state with `dev-cleanup`.

## Documentation

- [ ] Documentation updated
- [x] Documentation not needed

## Compatibility / breaking changes

- [x] No breaking changes
- [ ] Possible breaking changes described below

