### PR TITLE
fix replicaset manager

### DIFF
--- a/internal/condenser/core/pod/controller.go
+++ b/internal/condenser/core/pod/controller.go
@@ -70,6 +70,7 @@ func (c *PodController) reconcileOnce() error {
 		}
 		for _, rs := range replicaSets {
 			podList := podsByTemplate[rs.Spec.TemplateId]
+			podList = c.cleanupStoppedManagedPods(podList)
 			current := len(podList)
 			if current < rs.Spec.Replicas {
 				for i := 0; i < rs.Spec.Replicas-current; i++ {
@@ -216,6 +217,20 @@ func (c *PodController) reconcileOnce() error {
 	}
 
 	return nil
+}
+
+func (c *PodController) cleanupStoppedManagedPods(pods []psm.PodInfo) []psm.PodInfo {
+	active := make([]psm.PodInfo, 0, len(pods))
+	for _, p := range pods {
+		if !p.StoppedByUser {
+			active = append(active, p)
+			continue
+		}
+		if err := c.deletePod(p); err != nil {
+			log.Printf("pod controller delete stopped managed pod failed: podId=%s err=%v", p.PodId, err)
+		}
+	}
+	return active
 }
 
 func (c *PodController) reconcileDeployments() error {

--- a/internal/condenser/core/pod/controller_test.go
+++ b/internal/condenser/core/pod/controller_test.go
@@ -64,6 +64,73 @@ func TestPodControllerRecreatesReplicaSetPodWhenInfraIsStopped(t *testing.T) {
 	}
 }
 
+func TestPodControllerReplacesUserStoppedReplicaSetPod(t *testing.T) {
+	psmHandler := &fakeControllerPsm{
+		replicaSets: []psm.ReplicaSetInfo{{
+			ReplicaSetId: "rs-1",
+			Spec: psm.ReplicaSetSpec{
+				Name:       "demo-web",
+				Namespace:  "demo",
+				Replicas:   2,
+				TemplateId: "tpl-1",
+			},
+		}},
+		templates: []psm.PodTemplateInfo{{TemplateId: "tpl-1"}},
+		pods: map[string]psm.PodInfo{
+			"pod-running": {
+				PodId:      "pod-running",
+				TemplateId: "tpl-1",
+				Name:       "demo-web-running",
+				Namespace:  "demo",
+				State:      "running",
+			},
+			"pod-stopped": {
+				PodId:         "pod-stopped",
+				TemplateId:    "tpl-1",
+				Name:          "demo-web-stopped",
+				Namespace:     "demo",
+				State:         "stopped",
+				StoppedByUser: true,
+			},
+		},
+	}
+	podHandler := &fakeControllerPodService{createPodId: "pod-replacement"}
+	containerHandler := &fakeControllerContainerService{
+		containersByPod: map[string][]container.ContainerState{
+			"pod-running": {
+				{ContainerId: "infra-running", Name: utils.PodInfraContainerNamePrefix + "pod-running", PodId: "pod-running", State: "running"},
+				{ContainerId: "member-running", Name: "web", PodId: "pod-running", State: "running"},
+			},
+			"pod-stopped": {
+				{ContainerId: "infra-stopped", Name: utils.PodInfraContainerNamePrefix + "pod-stopped", PodId: "pod-stopped", State: "running"},
+				{ContainerId: "member-stopped", Name: "web", PodId: "pod-stopped", State: "stopped"},
+			},
+		},
+	}
+	controller := &PodController{
+		psmHandler:       psmHandler,
+		podHandler:       podHandler,
+		containerHandler: containerHandler,
+	}
+
+	if err := controller.reconcileOnce(); err != nil {
+		t.Fatalf("reconcileOnce returned error: %v", err)
+	}
+
+	if !psmHandler.removedPods["pod-stopped"] {
+		t.Fatalf("expected user-stopped managed pod to be removed")
+	}
+	if !containerHandler.stopped["infra-stopped"] || !containerHandler.deleted["infra-stopped"] || !containerHandler.deleted["member-stopped"] {
+		t.Fatalf("expected stopped managed pod containers to be cleaned up")
+	}
+	if podHandler.createdTemplateId != "tpl-1" {
+		t.Fatalf("expected replacement pod to be created from template tpl-1, got %q", podHandler.createdTemplateId)
+	}
+	if podHandler.startedPodId != "pod-replacement" {
+		t.Fatalf("expected replacement pod to be started, got %q", podHandler.startedPodId)
+	}
+}
+
 type fakeControllerPsm struct {
 	pods        map[string]psm.PodInfo
 	templates   []psm.PodTemplateInfo
@@ -145,6 +212,9 @@ func (f *fakeControllerPsm) IsPodOwner(string) bool                      { retur
 func (f *fakeControllerPsm) GetPodOwnerPid(string) (int, error)          { return 0, nil }
 
 type fakeControllerPodService struct {
+	createPodId         string
+	createdTemplateId   string
+	createdName         string
 	recreatePodId       string
 	recreatedTemplateId string
 	startedPodId        string
@@ -155,7 +225,11 @@ func (f *fakeControllerPodService) RecreateFromTemplate(templateId string) (stri
 	f.recreatedTemplateId = templateId
 	return f.recreatePodId, nil
 }
-func (f *fakeControllerPodService) CreateFromTemplate(string, string) (string, error) { return "", nil }
+func (f *fakeControllerPodService) CreateFromTemplate(templateId, name string) (string, error) {
+	f.createdTemplateId = templateId
+	f.createdName = name
+	return f.createPodId, nil
+}
 func (f *fakeControllerPodService) Start(podId string) (string, error) {
 	f.startedPodId = podId
 	return podId, nil


### PR DESCRIPTION
## Summary

Replace ReplicaSet-managed Pods that were manually stopped by the user so managed workloads continue converging to the desired replica count.

This PR updates PodController reconciliation to retire `StoppedByUser` Pods from ReplicaSet-managed Pod lists before counting current replicas. The controller deletes those stopped managed Pods and creates replacements when the active replica count is below the desired count.

## Motivation

Fixes: #52 

ReplicaSet reconciliation counted all Pods with the matching template toward `current`, including Pods marked `StoppedByUser`.

Those Pods were later skipped by reconcile, which meant a manually stopped managed Pod could keep a ReplicaSet or Deployment under-provisioned: the stopped Pod still satisfied the counted replica total, but it was not restarted or replaced.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactoring
- [x] Test improvement
- [ ] Build / CI / packaging
- [ ] Security hardening

## Affected areas

- [ ] CLI
- [x] Condenser API / controller
- [ ] Droplet runtime
- [ ] Container lifecycle
- [ ] Container exec / exec-shim
- [ ] Rootless containers
- [ ] Image handling
- [ ] Networking / policy / netflow
- [x] Kubernetes-style resources
- [ ] Snap / packaging
- [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

- [ ] namespaces
- [ ] mount / rootfs / pivot_root
- [ ] cgroups
- [ ] capabilities
- [ ] seccomp
- [ ] AppArmor
- [ ] rootless UID/GID mappings
- [ ] certificate / API authentication
- [ ] network namespace / iptables / nftables
- [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

No security-sensitive runtime primitives are changed. This PR changes controller reconciliation behavior for managed Pods only.

## Testing

Commands run:

```sh
workshop run -- test-unit
workshop run -- dev-cleanup && workshop run -- test-e2e
```

Results:

- `test-unit` passed.
- `test-e2e` passed after resetting the Workshop runtime state with `dev-cleanup`.

## Documentation

- [ ] Documentation updated
- [x] Documentation not needed

## Compatibility / breaking changes

- [x] No breaking changes
- [ ] Possible breaking changes described below

