### PR TITLE
enhancement

### DIFF
--- a/internal/condenser/api/http/pod/handler.go
+++ b/internal/condenser/api/http/pod/handler.go
@@ -916,7 +916,7 @@ func (h *RequestHandler) GetReplicaSetList(w http.ResponseWriter, r *http.Reques
 		current := 0
 		ready := 0
 		for _, p := range pods {
-			if p.TemplateId != rs.Spec.TemplateId {
+			if !replicaSetOwnsPod(rs, p) {
 				continue
 			}
 			current++
@@ -929,16 +929,19 @@ func (h *RequestHandler) GetReplicaSetList(w http.ResponseWriter, r *http.Reques
 			}
 		}
 		res = append(res, ReplicaSetSummary{
-			ReplicaSetId: rs.ReplicaSetId,
-			Name:         rs.Spec.Name,
-			Namespace:    rs.Spec.Namespace,
-			Replicas:     rs.Spec.Replicas,
-			Desired:      rs.Spec.Replicas,
-			Current:      current,
-			Ready:        ready,
-			TemplateId:   rs.Spec.TemplateId,
-			Selector:     rs.Spec.Selector,
-			CreatedAt:    rs.CreatedAt.Format(time.RFC3339),
+			ReplicaSetId:       rs.ReplicaSetId,
+			Name:               rs.Spec.Name,
+			Namespace:          rs.Spec.Namespace,
+			Replicas:           rs.Spec.Replicas,
+			Desired:            rs.Spec.Replicas,
+			Current:            current,
+			Ready:              ready,
+			TemplateId:         rs.Spec.TemplateId,
+			Selector:           rs.Spec.Selector,
+			ReconcileAttempt:   rs.ReconcileAttempt,
+			LastReconcileError: rs.LastReconcileError,
+			NextReconcileAt:    formatOptionalTime(rs.NextReconcileAt),
+			CreatedAt:          rs.CreatedAt.Format(time.RFC3339),
 		})
 	}
 	apimodel.RespondSuccess(w, http.StatusOK, "replicaset list", res)
@@ -976,7 +979,7 @@ func (h *RequestHandler) GetReplicaSetById(w http.ResponseWriter, r *http.Reques
 	ready := 0
 	templateCount := len(template.Spec.Containers)
 	for _, p := range pods {
-		if p.TemplateId != rs.Spec.TemplateId {
+		if !replicaSetOwnsPod(rs, p) {
 			continue
 		}
 		current++
@@ -989,17 +992,27 @@ func (h *RequestHandler) GetReplicaSetById(w http.ResponseWriter, r *http.Reques
 		}
 	}
 	apimodel.RespondSuccess(w, http.StatusOK, "replicaset detail", ReplicaSetDetail{
-		ReplicaSetId: rs.ReplicaSetId,
-		Name:         rs.Spec.Name,
-		Namespace:    rs.Spec.Namespace,
-		Replicas:     rs.Spec.Replicas,
-		Desired:      rs.Spec.Replicas,
-		Current:      current,
-		Ready:        ready,
-		Selector:     rs.Spec.Selector,
-		Template:     template.Spec,
-		CreatedAt:    rs.CreatedAt.Format(time.RFC3339),
+		ReplicaSetId:       rs.ReplicaSetId,
+		Name:               rs.Spec.Name,
+		Namespace:          rs.Spec.Namespace,
+		Replicas:           rs.Spec.Replicas,
+		Desired:            rs.Spec.Replicas,
+		Current:            current,
+		Ready:              ready,
+		Selector:           rs.Spec.Selector,
+		Template:           template.Spec,
+		ReconcileAttempt:   rs.ReconcileAttempt,
+		LastReconcileError: rs.LastReconcileError,
+		NextReconcileAt:    formatOptionalTime(rs.NextReconcileAt),
+		CreatedAt:          rs.CreatedAt.Format(time.RFC3339),
 	})
+}
+
+func formatOptionalTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
 }
 
 // RemoveReplicaSet godoc
@@ -1039,7 +1052,7 @@ func (h *RequestHandler) deploymentReplicaCounts(deploy psm.DeploymentInfo) (int
 	current := 0
 	ready := 0
 	for _, p := range pods {
-		if p.TemplateId != rs.Spec.TemplateId {
+		if !replicaSetOwnsPod(rs, p) {
 			continue
 		}
 		current++
@@ -1052,6 +1065,13 @@ func (h *RequestHandler) deploymentReplicaCounts(deploy psm.DeploymentInfo) (int
 		}
 	}
 	return current, ready, nil
+}
+
+func replicaSetOwnsPod(rs psm.ReplicaSetInfo, p psm.PodInfo) bool {
+	if p.OwnerKind == psm.OwnerKindReplicaSet || p.OwnerId != "" {
+		return p.OwnerKind == psm.OwnerKindReplicaSet && p.OwnerId == rs.ReplicaSetId
+	}
+	return p.TemplateId == rs.Spec.TemplateId
 }
 
 // ScaleDeployment godoc

--- a/internal/condenser/api/http/pod/model.go
+++ b/internal/condenser/api/http/pod/model.go
@@ -173,29 +173,35 @@ type ScaleReplicaSetResponse struct {
 }
 
 type ReplicaSetSummary struct {
-	ReplicaSetId string            `json:"replicaSetId"`
-	Name         string            `json:"name"`
-	Namespace    string            `json:"namespace"`
-	Replicas     int               `json:"replicas"`
-	Desired      int               `json:"desired"`
-	Current      int               `json:"current"`
-	Ready        int               `json:"ready"`
-	TemplateId   string            `json:"templateId"`
-	Selector     map[string]string `json:"selector,omitempty"`
-	CreatedAt    string            `json:"createdAt"`
+	ReplicaSetId       string            `json:"replicaSetId"`
+	Name               string            `json:"name"`
+	Namespace          string            `json:"namespace"`
+	Replicas           int               `json:"replicas"`
+	Desired            int               `json:"desired"`
+	Current            int               `json:"current"`
+	Ready              int               `json:"ready"`
+	TemplateId         string            `json:"templateId"`
+	Selector           map[string]string `json:"selector,omitempty"`
+	ReconcileAttempt   int               `json:"reconcileAttempt,omitempty"`
+	LastReconcileError string            `json:"lastReconcileError,omitempty"`
+	NextReconcileAt    string            `json:"nextReconcileAt,omitempty"`
+	CreatedAt          string            `json:"createdAt"`
 }
 
 type ReplicaSetDetail struct {
-	ReplicaSetId string              `json:"replicaSetId"`
-	Name         string              `json:"name"`
-	Namespace    string              `json:"namespace"`
-	Replicas     int                 `json:"replicas"`
-	Desired      int                 `json:"desired"`
-	Current      int                 `json:"current"`
-	Ready        int                 `json:"ready"`
-	Selector     map[string]string   `json:"selector,omitempty"`
-	Template     psm.PodTemplateSpec `json:"template"`
-	CreatedAt    string              `json:"createdAt"`
+	ReplicaSetId       string              `json:"replicaSetId"`
+	Name               string              `json:"name"`
+	Namespace          string              `json:"namespace"`
+	Replicas           int                 `json:"replicas"`
+	Desired            int                 `json:"desired"`
+	Current            int                 `json:"current"`
+	Ready              int                 `json:"ready"`
+	Selector           map[string]string   `json:"selector,omitempty"`
+	Template           psm.PodTemplateSpec `json:"template"`
+	ReconcileAttempt   int                 `json:"reconcileAttempt,omitempty"`
+	LastReconcileError string              `json:"lastReconcileError,omitempty"`
+	NextReconcileAt    string              `json:"nextReconcileAt,omitempty"`
+	CreatedAt          string              `json:"createdAt"`
 }
 
 type StartPodResponse struct {

--- a/internal/condenser/core/container/service_test.go
+++ b/internal/condenser/core/container/service_test.go
@@ -485,6 +485,8 @@ func (f *fakePsmHandler) StorePod(req psm.StorePodRequest) error {
 	f.pods[req.PodId] = psm.PodInfo{
 		PodId:       req.PodId,
 		TemplateId:  req.TemplateId,
+		OwnerKind:   req.OwnerKind,
+		OwnerId:     req.OwnerId,
 		Name:        req.Name,
 		Namespace:   req.Namespace,
 		UID:         req.UID,
@@ -515,6 +517,10 @@ func (f *fakePsmHandler) GetReplicaSet(string) (psm.ReplicaSetInfo, error) {
 func (f *fakePsmHandler) GetReplicaSetList() ([]psm.ReplicaSetInfo, error) { return nil, nil }
 func (f *fakePsmHandler) IsTemplateReferenced(string) (bool, error)        { return false, nil }
 func (f *fakePsmHandler) UpdateReplicaSetReplicas(string, int) error       { return nil }
+func (f *fakePsmHandler) UpdateReplicaSetReconcileStatus(string, int, string, time.Time) error {
+	return nil
+}
+func (f *fakePsmHandler) ClearReplicaSetReconcileStatus(string) error      { return nil }
 func (f *fakePsmHandler) RemoveReplicaSet(string) error                    { return nil }
 func (f *fakePsmHandler) StoreDeployment(string, psm.DeploymentSpec) error { return nil }
 func (f *fakePsmHandler) GetDeployment(string) (psm.DeploymentInfo, error) {
@@ -526,6 +532,7 @@ func (f *fakePsmHandler) UpdateDeploymentReplicaSet(string, string) error  { ret
 func (f *fakePsmHandler) RemoveDeployment(string) error                    { return nil }
 func (f *fakePsmHandler) RemovePod(string) error                           { return nil }
 func (f *fakePsmHandler) UpdatePod(string, string) error                   { return nil }
+func (f *fakePsmHandler) UpdatePodOwner(string, string, string) error      { return nil }
 func (f *fakePsmHandler) UpdatePodStoppedByUser(string, bool) error        { return nil }
 func (f *fakePsmHandler) UpdatePodNamespaces(int, string, string, string, string, string) error {
 	return nil

--- a/internal/condenser/core/pod/controller.go
+++ b/internal/condenser/core/pod/controller.go
@@ -61,16 +61,18 @@ func (c *PodController) reconcileOnce() error {
 
 	// ReplicaSet reconcile
 	if len(replicaSets) > 0 {
-		podsByTemplate := make(map[string][]psm.PodInfo, len(templates))
-		for _, p := range pods {
-			if p.TemplateId == "" {
+		templateRefs := replicaSetTemplateRefs(replicaSets)
+		for _, rs := range replicaSets {
+			if shouldSkipReplicaSet(rs) {
 				continue
 			}
-			podsByTemplate[p.TemplateId] = append(podsByTemplate[p.TemplateId], p)
-		}
-		for _, rs := range replicaSets {
-			podList := podsByTemplate[rs.Spec.TemplateId]
-			podList = c.cleanupStoppedManagedPods(podList)
+			var reconcileErr error
+			podList := filterReplicaSetPods(rs, pods, templateRefs)
+			podList, reconcileErr = c.cleanupStoppedManagedPods(podList)
+			if reconcileErr != nil {
+				c.recordReplicaSetReconcileError(rs, reconcileErr)
+				continue
+			}
 			current := len(podList)
 			if current < rs.Spec.Replicas {
 				for i := 0; i < rs.Spec.Replicas-current; i++ {
@@ -78,10 +80,17 @@ func (c *PodController) reconcileOnce() error {
 					podId, err := c.podHandler.CreateFromTemplate(rs.Spec.TemplateId, name)
 					if err != nil {
 						log.Printf("pod controller recreate failed: templateId=%s err=%v", rs.Spec.TemplateId, err)
+						reconcileErr = err
+						break
+					}
+					if err := c.psmHandler.UpdatePodOwner(podId, psm.OwnerKindReplicaSet, rs.ReplicaSetId); err != nil {
+						log.Printf("pod controller owner update failed: podId=%s err=%v", podId, err)
+						reconcileErr = err
 						break
 					}
 					if _, err := c.podHandler.Start(podId); err != nil {
 						log.Printf("pod controller start failed: podId=%s err=%v", podId, err)
+						reconcileErr = err
 						if podInfo, getErr := c.psmHandler.GetPodById(podId); getErr == nil {
 							if delErr := c.deletePod(podInfo); delErr != nil {
 								log.Printf("pod controller cleanup failed: podId=%s err=%v", podId, delErr)
@@ -94,8 +103,14 @@ func (c *PodController) reconcileOnce() error {
 				for i := 0; i < excess; i++ {
 					if err := c.deletePod(podList[i]); err != nil {
 						log.Printf("pod controller delete failed: podId=%s err=%v", podList[i].PodId, err)
+						reconcileErr = err
+						break
 					}
 				}
+			}
+			if reconcileErr != nil {
+				c.recordReplicaSetReconcileError(rs, reconcileErr)
+				continue
 			}
 			for _, p := range podList {
 				if p.StoppedByUser {
@@ -110,37 +125,47 @@ func (c *PodController) reconcileOnce() error {
 				infraState, err := c.getPodInfraState(p.PodId)
 				if err != nil {
 					log.Printf("pod controller infra check failed: podId=%s err=%v", p.PodId, err)
+					reconcileErr = err
 					continue
 				}
-				if infraState != "running" {
+				if infraState != psm.ContainerStateRunning {
 					if err := c.recreatePod(p); err != nil {
 						log.Printf("pod controller recreate failed: podId=%s err=%v", p.PodId, err)
+						reconcileErr = err
 					}
 					continue
 				}
 
-				if p.State == "degraded" {
+				if p.State == psm.PodStateDegraded {
 					// Infra is running, so only recover member containers.
 					if _, err := c.podHandler.Start(p.PodId); err != nil {
 						log.Printf("pod controller start failed: podId=%s err=%v", p.PodId, err)
+						reconcileErr = err
 					}
 					continue
 				}
-				if p.State == "stopped" {
+				if p.State == psm.PodStateStopped {
 					if _, err := c.podHandler.Start(p.PodId); err != nil {
 						log.Printf("pod controller start failed: podId=%s err=%v", p.PodId, err)
+						reconcileErr = err
 					}
 					continue
 				}
-				if p.State == "created" {
+				if p.State == psm.PodStateCreated {
 					if _, err := c.podHandler.Start(p.PodId); err != nil {
 						log.Printf("pod controller start failed: podId=%s err=%v", p.PodId, err)
+						reconcileErr = err
 						if err := c.recreatePod(p); err != nil {
 							log.Printf("pod controller recreate failed: podId=%s err=%v", p.PodId, err)
 						}
 					}
 				}
 			}
+			if reconcileErr != nil {
+				c.recordReplicaSetReconcileError(rs, reconcileErr)
+				continue
+			}
+			c.clearReplicaSetReconcileStatus(rs)
 		}
 	}
 	podsByTemplate := make(map[string][]psm.PodInfo, len(templates))
@@ -172,7 +197,7 @@ func (c *PodController) reconcileOnce() error {
 		var degradedPodId string
 		var stoppedPodId string
 		for _, p := range podList {
-			if p.State == "created" {
+			if p.State == psm.PodStateCreated {
 				hasActive = true
 				break
 			}
@@ -188,10 +213,10 @@ func (c *PodController) reconcileOnce() error {
 					break
 				}
 			}
-			if p.State == "degraded" && !p.StoppedByUser && degradedPodId == "" {
+			if p.State == psm.PodStateDegraded && !p.StoppedByUser && degradedPodId == "" {
 				degradedPodId = p.PodId
 			}
-			if p.State != "stopped" {
+			if p.State != psm.PodStateStopped {
 				hasActive = true
 				break
 			}
@@ -219,7 +244,68 @@ func (c *PodController) reconcileOnce() error {
 	return nil
 }
 
-func (c *PodController) cleanupStoppedManagedPods(pods []psm.PodInfo) []psm.PodInfo {
+func replicaSetTemplateRefs(replicaSets []psm.ReplicaSetInfo) map[string]int {
+	refs := make(map[string]int, len(replicaSets))
+	for _, rs := range replicaSets {
+		refs[rs.Spec.TemplateId]++
+	}
+	return refs
+}
+
+func filterReplicaSetPods(rs psm.ReplicaSetInfo, pods []psm.PodInfo, templateRefs map[string]int) []psm.PodInfo {
+	out := make([]psm.PodInfo, 0, len(pods))
+	for _, p := range pods {
+		if p.OwnerKind == psm.OwnerKindReplicaSet || p.OwnerId != "" {
+			if p.OwnerKind == psm.OwnerKindReplicaSet && p.OwnerId == rs.ReplicaSetId {
+				out = append(out, p)
+			}
+			continue
+		}
+		if p.TemplateId == rs.Spec.TemplateId && templateRefs[rs.Spec.TemplateId] == 1 && strings.HasPrefix(p.Name, rs.Spec.Name+"-") {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func shouldSkipReplicaSet(rs psm.ReplicaSetInfo) bool {
+	return !rs.NextReconcileAt.IsZero() && time.Now().Before(rs.NextReconcileAt)
+}
+
+func (c *PodController) recordReplicaSetReconcileError(rs psm.ReplicaSetInfo, err error) {
+	if err == nil {
+		return
+	}
+	attempt := rs.ReconcileAttempt + 1
+	delay := time.Duration(1<<min(attempt-1, 6)) * c.interval
+	if delay <= 0 {
+		delay = 5 * time.Second
+	}
+	if delay > time.Minute {
+		delay = time.Minute
+	}
+	if statusErr := c.psmHandler.UpdateReplicaSetReconcileStatus(rs.ReplicaSetId, attempt, err.Error(), time.Now().Add(delay)); statusErr != nil {
+		log.Printf("pod controller reconcile status update failed: replicaSetId=%s err=%v", rs.ReplicaSetId, statusErr)
+	}
+}
+
+func (c *PodController) clearReplicaSetReconcileStatus(rs psm.ReplicaSetInfo) {
+	if rs.ReconcileAttempt == 0 && rs.LastReconcileError == "" && rs.NextReconcileAt.IsZero() {
+		return
+	}
+	if err := c.psmHandler.ClearReplicaSetReconcileStatus(rs.ReplicaSetId); err != nil {
+		log.Printf("pod controller reconcile status clear failed: replicaSetId=%s err=%v", rs.ReplicaSetId, err)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (c *PodController) cleanupStoppedManagedPods(pods []psm.PodInfo) ([]psm.PodInfo, error) {
 	active := make([]psm.PodInfo, 0, len(pods))
 	for _, p := range pods {
 		if !p.StoppedByUser {
@@ -228,9 +314,10 @@ func (c *PodController) cleanupStoppedManagedPods(pods []psm.PodInfo) []psm.PodI
 		}
 		if err := c.deletePod(p); err != nil {
 			log.Printf("pod controller delete stopped managed pod failed: podId=%s err=%v", p.PodId, err)
+			return active, err
 		}
 	}
-	return active
+	return active, nil
 }
 
 func (c *PodController) reconcileDeployments() error {
@@ -294,7 +381,7 @@ func (c *PodController) isPodInfraDown(podId string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return state != "running", nil
+	return state != psm.ContainerStateRunning, nil
 }
 
 func (c *PodController) getPodInfraState(podId string) (string, error) {
@@ -305,15 +392,26 @@ func (c *PodController) getPodInfraState(podId string) (string, error) {
 	if len(containers) == 0 {
 		return "missing", nil
 	}
+	runningInfra := 0
+	stoppedInfra := 0
 	for _, cinfo := range containers {
 		if strings.HasPrefix(cinfo.Name, utils.PodInfraContainerNamePrefix) {
-			if cinfo.State == "running" {
-				return "running", nil
+			if cinfo.State == psm.ContainerStateRunning {
+				runningInfra++
+				continue
 			}
-			return "stopped", nil
+			stoppedInfra++
 		}
 	}
-	// infra missing
+	if runningInfra == 1 && stoppedInfra == 0 {
+		return psm.ContainerStateRunning, nil
+	}
+	if runningInfra > 1 {
+		return "duplicate", nil
+	}
+	if stoppedInfra > 0 {
+		return psm.ContainerStateStopped, nil
+	}
 	return "missing", nil
 }
 
@@ -323,7 +421,7 @@ func (c *PodController) recreatePod(podInfo psm.PodInfo) error {
 		return err
 	}
 	for _, cinfo := range containers {
-		if cinfo.State == "running" {
+		if cinfo.State == psm.ContainerStateRunning {
 			_, _ = c.containerHandler.Stop(container.ServiceStopModel{ContainerId: cinfo.ContainerId})
 		}
 		_, _ = c.containerHandler.Delete(container.ServiceDeleteModel{ContainerId: cinfo.ContainerId})
@@ -341,6 +439,11 @@ func (c *PodController) recreatePod(podInfo psm.PodInfo) error {
 	if err != nil {
 		return err
 	}
+	if podInfo.OwnerKind != "" || podInfo.OwnerId != "" {
+		if err := c.psmHandler.UpdatePodOwner(newPodId, podInfo.OwnerKind, podInfo.OwnerId); err != nil {
+			return err
+		}
+	}
 	_, err = c.podHandler.Start(newPodId)
 	return err
 }
@@ -354,7 +457,7 @@ func (c *PodController) deletePod(podInfo psm.PodInfo) error {
 		return err
 	}
 	for _, cinfo := range containers {
-		if cinfo.State == "running" {
+		if cinfo.State == psm.ContainerStateRunning {
 			_, _ = c.containerHandler.Stop(container.ServiceStopModel{ContainerId: cinfo.ContainerId})
 		}
 		_, _ = c.containerHandler.Delete(container.ServiceDeleteModel{ContainerId: cinfo.ContainerId})

--- a/internal/condenser/core/pod/controller_test.go
+++ b/internal/condenser/core/pod/controller_test.go
@@ -1,8 +1,10 @@
 package pod
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"raind/internal/condenser/core/container"
 	"raind/internal/condenser/store/psm"
@@ -131,12 +133,96 @@ func TestPodControllerReplacesUserStoppedReplicaSetPod(t *testing.T) {
 	}
 }
 
+func TestFilterReplicaSetPodsUsesExplicitOwner(t *testing.T) {
+	rs := psm.ReplicaSetInfo{
+		ReplicaSetId: "rs-1",
+		Spec:         psm.ReplicaSetSpec{TemplateId: "tpl-1"},
+	}
+	pods := []psm.PodInfo{
+		{PodId: "owned", TemplateId: "tpl-1", OwnerKind: psm.OwnerKindReplicaSet, OwnerId: "rs-1"},
+		{PodId: "other-owner", TemplateId: "tpl-1", OwnerKind: psm.OwnerKindReplicaSet, OwnerId: "rs-2"},
+		{PodId: "unowned-ambiguous", TemplateId: "tpl-1"},
+	}
+
+	got := filterReplicaSetPods(rs, pods, map[string]int{"tpl-1": 2})
+
+	if len(got) != 1 || got[0].PodId != "owned" {
+		t.Fatalf("expected only explicitly owned pod, got %#v", got)
+	}
+}
+
+func TestPodControllerTreatsMultipleRunningInfraAsUnhealthy(t *testing.T) {
+	controller := &PodController{
+		containerHandler: &fakeControllerContainerService{
+			containersByPod: map[string][]container.ContainerState{
+				"pod-1": {
+					{ContainerId: "infra-1", Name: utils.PodInfraContainerNamePrefix + "pod-1", PodId: "pod-1", State: psm.ContainerStateRunning},
+					{ContainerId: "infra-2", Name: utils.PodInfraContainerNamePrefix + "pod-1-copy", PodId: "pod-1", State: psm.ContainerStateRunning},
+					{ContainerId: "member-1", Name: "web", PodId: "pod-1", State: psm.ContainerStateRunning},
+				},
+			},
+		},
+	}
+
+	state, err := controller.getPodInfraState("pod-1")
+
+	if err != nil {
+		t.Fatalf("getPodInfraState returned error: %v", err)
+	}
+	if state != "duplicate" {
+		t.Fatalf("expected duplicate infra state, got %q", state)
+	}
+}
+
+func TestPodControllerRecordsBackoffWhenReplicaSetReconcileFails(t *testing.T) {
+	psmHandler := &fakeControllerPsm{
+		replicaSets: []psm.ReplicaSetInfo{{
+			ReplicaSetId: "rs-1",
+			Spec: psm.ReplicaSetSpec{
+				Name:       "demo-web",
+				Namespace:  "demo",
+				Replicas:   1,
+				TemplateId: "tpl-1",
+			},
+		}},
+		templates: []psm.PodTemplateInfo{{TemplateId: "tpl-1"}},
+		pods:      map[string]psm.PodInfo{},
+	}
+	podHandler := &fakeControllerPodService{
+		createPodId: "pod-new",
+		startErr:    errors.New("start failed"),
+	}
+	controller := &PodController{
+		psmHandler:       psmHandler,
+		podHandler:       podHandler,
+		containerHandler: &fakeControllerContainerService{},
+		interval:         time.Second,
+	}
+
+	if err := controller.reconcileOnce(); err != nil {
+		t.Fatalf("reconcileOnce returned error: %v", err)
+	}
+
+	if psmHandler.reconcileAttempts["rs-1"] != 1 {
+		t.Fatalf("expected reconcile attempt to be recorded, got %d", psmHandler.reconcileAttempts["rs-1"])
+	}
+	if psmHandler.reconcileErrors["rs-1"] != "start failed" {
+		t.Fatalf("expected reconcile error to be recorded, got %q", psmHandler.reconcileErrors["rs-1"])
+	}
+}
+
 type fakeControllerPsm struct {
 	pods        map[string]psm.PodInfo
 	templates   []psm.PodTemplateInfo
 	replicaSets []psm.ReplicaSetInfo
 	deployments []psm.DeploymentInfo
 	removedPods map[string]bool
+	owners      map[string]struct {
+		kind string
+		id   string
+	}
+	reconcileAttempts map[string]int
+	reconcileErrors   map[string]string
 }
 
 func (f *fakeControllerPsm) StorePod(psm.StorePodRequest) error                 { return nil }
@@ -158,8 +244,28 @@ func (f *fakeControllerPsm) GetReplicaSet(string) (psm.ReplicaSetInfo, error) {
 func (f *fakeControllerPsm) GetReplicaSetList() ([]psm.ReplicaSetInfo, error) {
 	return f.replicaSets, nil
 }
-func (f *fakeControllerPsm) IsTemplateReferenced(string) (bool, error)        { return true, nil }
-func (f *fakeControllerPsm) UpdateReplicaSetReplicas(string, int) error       { return nil }
+func (f *fakeControllerPsm) IsTemplateReferenced(string) (bool, error)  { return true, nil }
+func (f *fakeControllerPsm) UpdateReplicaSetReplicas(string, int) error { return nil }
+func (f *fakeControllerPsm) UpdateReplicaSetReconcileStatus(replicaSetId string, attempt int, lastError string, nextReconcileAt time.Time) error {
+	if f.reconcileAttempts == nil {
+		f.reconcileAttempts = make(map[string]int)
+	}
+	if f.reconcileErrors == nil {
+		f.reconcileErrors = make(map[string]string)
+	}
+	f.reconcileAttempts[replicaSetId] = attempt
+	f.reconcileErrors[replicaSetId] = lastError
+	return nil
+}
+func (f *fakeControllerPsm) ClearReplicaSetReconcileStatus(replicaSetId string) error {
+	if f.reconcileAttempts != nil {
+		delete(f.reconcileAttempts, replicaSetId)
+	}
+	if f.reconcileErrors != nil {
+		delete(f.reconcileErrors, replicaSetId)
+	}
+	return nil
+}
 func (f *fakeControllerPsm) RemoveReplicaSet(string) error                    { return nil }
 func (f *fakeControllerPsm) StoreDeployment(string, psm.DeploymentSpec) error { return nil }
 func (f *fakeControllerPsm) GetDeployment(string) (psm.DeploymentInfo, error) {
@@ -182,7 +288,20 @@ func (f *fakeControllerPsm) RemovePod(podId string) error {
 	delete(f.pods, podId)
 	return nil
 }
-func (f *fakeControllerPsm) UpdatePod(string, string) error            { return nil }
+func (f *fakeControllerPsm) UpdatePod(string, string) error { return nil }
+func (f *fakeControllerPsm) UpdatePodOwner(podId, ownerKind, ownerId string) error {
+	if f.owners == nil {
+		f.owners = make(map[string]struct {
+			kind string
+			id   string
+		})
+	}
+	f.owners[podId] = struct {
+		kind string
+		id   string
+	}{kind: ownerKind, id: ownerId}
+	return nil
+}
 func (f *fakeControllerPsm) UpdatePodStoppedByUser(string, bool) error { return nil }
 func (f *fakeControllerPsm) UpdatePodNamespaces(int, string, string, string, string, string) error {
 	return nil
@@ -218,6 +337,7 @@ type fakeControllerPodService struct {
 	recreatePodId       string
 	recreatedTemplateId string
 	startedPodId        string
+	startErr            error
 }
 
 func (f *fakeControllerPodService) Create(ServiceCreateModel) (string, error) { return "", nil }
@@ -231,6 +351,9 @@ func (f *fakeControllerPodService) CreateFromTemplate(templateId, name string) (
 	return f.createPodId, nil
 }
 func (f *fakeControllerPodService) Start(podId string) (string, error) {
+	if f.startErr != nil {
+		return "", f.startErr
+	}
 	f.startedPodId = podId
 	return podId, nil
 }

--- a/internal/condenser/core/pod/service_create.go
+++ b/internal/condenser/core/pod/service_create.go
@@ -99,7 +99,7 @@ func (s *PodService) createWithTemplate(templateId string, createParameter Servi
 		Name:        createParameter.Name,
 		Namespace:   createParameter.Namespace,
 		UID:         createParameter.UID,
-		State:       "created",
+		State:       psm.PodStateCreated,
 		NetworkNS:   createParameter.NetworkNS,
 		IPCNS:       createParameter.IPCNS,
 		UTSNS:       createParameter.UTSNS,

--- a/internal/condenser/core/pod/service_list.go
+++ b/internal/condenser/core/pod/service_list.go
@@ -1,5 +1,7 @@
 package pod
 
+import "raind/internal/condenser/store/psm"
+
 // == service: list pods ==
 func (s *PodService) GetPodList() ([]PodState, error) {
 	podList, err := s.psmHandler.GetPodList()
@@ -84,7 +86,7 @@ func (s *PodService) getContainerCounts(podId, templateId string) (int, int, err
 			continue
 		}
 		nonInfra++
-		if c.State == "running" {
+		if c.State == psm.ContainerStateRunning {
 			running++
 		}
 	}

--- a/internal/condenser/core/pod/service_start.go
+++ b/internal/condenser/core/pod/service_start.go
@@ -26,7 +26,7 @@ func (s *PodService) Start(podId string) (string, error) {
 
 	for _, c := range containers {
 		if s.isPodInfraName(c.Name) {
-			if c.State == "running" {
+			if c.State == psm.ContainerStateRunning {
 				continue
 			}
 			if _, err := s.containerHandler.Start(container.ServiceStartModel{ContainerId: c.ContainerId, Tty: false}); err != nil {
@@ -39,7 +39,7 @@ func (s *PodService) Start(podId string) (string, error) {
 		if s.isPodInfraName(c.Name) {
 			continue
 		}
-		if c.State == "running" {
+		if c.State == psm.ContainerStateRunning {
 			continue
 		}
 		if _, err := s.containerHandler.Start(container.ServiceStartModel{ContainerId: c.ContainerId, Tty: false}); err != nil {
@@ -47,7 +47,7 @@ func (s *PodService) Start(podId string) (string, error) {
 		}
 	}
 
-	if err := s.psmHandler.UpdatePod(podId, "running"); err != nil {
+	if err := s.psmHandler.UpdatePod(podId, psm.PodStateRunning); err != nil {
 		return "", err
 	}
 	_ = s.psmHandler.UpdatePodStoppedByUser(podId, false)

--- a/internal/condenser/core/pod/service_stop.go
+++ b/internal/condenser/core/pod/service_stop.go
@@ -1,6 +1,9 @@
 package pod
 
-import "raind/internal/condenser/core/container"
+import (
+	"raind/internal/condenser/core/container"
+	"raind/internal/condenser/store/psm"
+)
 
 // == service: stop pod sandbox ==
 func (s *PodService) Stop(podId string) (string, error) {
@@ -16,7 +19,7 @@ func (s *PodService) Stop(podId string) (string, error) {
 			return "", err
 		}
 	}
-	if err := s.psmHandler.UpdatePod(podId, "stopped"); err != nil {
+	if err := s.psmHandler.UpdatePod(podId, psm.PodStateStopped); err != nil {
 		return "", err
 	}
 	if err := s.psmHandler.UpdatePodStoppedByUser(podId, true); err != nil {

--- a/internal/condenser/core/service/controller.go
+++ b/internal/condenser/core/service/controller.go
@@ -129,7 +129,7 @@ func (c *ServiceController) buildEndpoints(svc ssm.ServiceInfo, pods []psm.PodIn
 }
 
 func (c *ServiceController) getReadyInfraContainerId(p psm.PodInfo) (string, bool) {
-	if p.State != "running" || p.StoppedByUser {
+	if p.State != psm.PodStateRunning || p.StoppedByUser {
 		return "", false
 	}
 
@@ -148,14 +148,14 @@ func (c *ServiceController) getReadyInfraContainerId(p psm.PodInfo) (string, boo
 	)
 	for _, cinfo := range containers {
 		if strings.HasPrefix(cinfo.Name, utils.PodInfraContainerNamePrefix) {
-			if cinfo.State != "running" {
+			if cinfo.State != psm.ContainerStateRunning {
 				return "", false
 			}
 			infraId = cinfo.ContainerId
 			continue
 		}
 		memberCount++
-		if cinfo.State != "running" {
+		if cinfo.State != psm.ContainerStateRunning {
 			return "", false
 		}
 		runningByName[cinfo.Name] = struct{}{}

--- a/internal/condenser/store/psm/interface.go
+++ b/internal/condenser/store/psm/interface.go
@@ -1,5 +1,7 @@
 package psm
 
+import "time"
+
 type PsmStoreHandler interface {
 	SetPodState() error
 }
@@ -16,6 +18,8 @@ type PsmHandler interface {
 	GetReplicaSetList() ([]ReplicaSetInfo, error)
 	IsTemplateReferenced(templateId string) (bool, error)
 	UpdateReplicaSetReplicas(replicaSetId string, replicas int) error
+	UpdateReplicaSetReconcileStatus(replicaSetId string, attempt int, lastError string, nextReconcileAt time.Time) error
+	ClearReplicaSetReconcileStatus(replicaSetId string) error
 	RemoveReplicaSet(replicaSetId string) error
 	StoreDeployment(deploymentId string, spec DeploymentSpec) error
 	GetDeployment(deploymentId string) (DeploymentInfo, error)
@@ -25,6 +29,7 @@ type PsmHandler interface {
 	RemoveDeployment(deploymentId string) error
 	RemovePod(podId string) error
 	UpdatePod(podId string, state string) error
+	UpdatePodOwner(podId, ownerKind, ownerId string) error
 	UpdatePodStoppedByUser(podId string, stopped bool) error
 	UpdatePodNamespaces(ownerPid int, podId, networkNS, ipcNS, utsNS, userNS string) error
 	ResetPodNamespaces(podId string) error

--- a/internal/condenser/store/psm/model.go
+++ b/internal/condenser/store/psm/model.go
@@ -2,9 +2,24 @@ package psm
 
 import "time"
 
+const (
+	PodStateCreated  = "created"
+	PodStateRunning  = "running"
+	PodStateStopped  = "stopped"
+	PodStateDegraded = "degraded"
+
+	ContainerStateCreated = "created"
+	ContainerStateRunning = "running"
+	ContainerStateStopped = "stopped"
+
+	OwnerKindReplicaSet = "ReplicaSet"
+)
+
 type PodInfo struct {
 	PodId         string            `json:"podId"`
 	TemplateId    string            `json:"templateId,omitempty"`
+	OwnerKind     string            `json:"ownerKind,omitempty"`
+	OwnerId       string            `json:"ownerId,omitempty"`
 	Name          string            `json:"name"`
 	Namespace     string            `json:"namespace"`
 	UID           string            `json:"uid"`
@@ -26,6 +41,8 @@ type PodInfo struct {
 type StorePodRequest struct {
 	PodId       string
 	TemplateId  string
+	OwnerKind   string
+	OwnerId     string
 	Name        string
 	Namespace   string
 	UID         string
@@ -81,9 +98,12 @@ type ReplicaSetSpec struct {
 }
 
 type ReplicaSetInfo struct {
-	ReplicaSetId string         `json:"replicaSetId"`
-	Spec         ReplicaSetSpec `json:"spec"`
-	CreatedAt    time.Time      `json:"createdAt"`
+	ReplicaSetId       string         `json:"replicaSetId"`
+	Spec               ReplicaSetSpec `json:"spec"`
+	CreatedAt          time.Time      `json:"createdAt"`
+	ReconcileAttempt   int            `json:"reconcileAttempt,omitempty"`
+	LastReconcileError string         `json:"lastReconcileError,omitempty"`
+	NextReconcileAt    time.Time      `json:"nextReconcileAt,omitempty"`
 }
 
 type DeploymentSpec struct {

--- a/internal/condenser/store/psm/psm.go
+++ b/internal/condenser/store/psm/psm.go
@@ -20,6 +20,8 @@ func (m *PsmManager) StorePod(req StorePodRequest) error {
 		st.Pods[req.PodId] = PodInfo{
 			PodId:       req.PodId,
 			TemplateId:  req.TemplateId,
+			OwnerKind:   req.OwnerKind,
+			OwnerId:     req.OwnerId,
 			Name:        req.Name,
 			Namespace:   req.Namespace,
 			UID:         req.UID,
@@ -163,6 +165,34 @@ func (m *PsmManager) UpdateReplicaSetReplicas(replicaSetId string, replicas int)
 	})
 }
 
+func (m *PsmManager) UpdateReplicaSetReconcileStatus(replicaSetId string, attempt int, lastError string, nextReconcileAt time.Time) error {
+	return m.psmStore.withLock(func(st *PodState) error {
+		rs, ok := st.ReplicaSets[replicaSetId]
+		if !ok {
+			return fmt.Errorf("replicaSetId=%s not found", replicaSetId)
+		}
+		rs.ReconcileAttempt = attempt
+		rs.LastReconcileError = lastError
+		rs.NextReconcileAt = nextReconcileAt
+		st.ReplicaSets[replicaSetId] = rs
+		return nil
+	})
+}
+
+func (m *PsmManager) ClearReplicaSetReconcileStatus(replicaSetId string) error {
+	return m.psmStore.withLock(func(st *PodState) error {
+		rs, ok := st.ReplicaSets[replicaSetId]
+		if !ok {
+			return fmt.Errorf("replicaSetId=%s not found", replicaSetId)
+		}
+		rs.ReconcileAttempt = 0
+		rs.LastReconcileError = ""
+		rs.NextReconcileAt = time.Time{}
+		st.ReplicaSets[replicaSetId] = rs
+		return nil
+	})
+}
+
 func (m *PsmManager) IsTemplateReferenced(templateId string) (bool, error) {
 	var referenced bool
 	err := m.psmStore.withRLock(func(st *PodState) error {
@@ -288,14 +318,27 @@ func (m *PsmManager) UpdatePod(podId string, state string) error {
 
 		p.State = state
 		switch state {
-		case "created":
+		case PodStateCreated:
 			p.CreatedAt = time.Now()
-		case "running":
+		case PodStateRunning:
 			p.StartedAt = time.Now()
-		case "stopped":
+		case PodStateStopped:
 			p.StoppedAt = time.Now()
 		}
 
+		st.Pods[podId] = p
+		return nil
+	})
+}
+
+func (m *PsmManager) UpdatePodOwner(podId, ownerKind, ownerId string) error {
+	return m.psmStore.withLock(func(st *PodState) error {
+		p, ok := st.Pods[podId]
+		if !ok {
+			return fmt.Errorf("podId=%s not found", podId)
+		}
+		p.OwnerKind = ownerKind
+		p.OwnerId = ownerId
 		st.Pods[podId] = p
 		return nil
 	})

--- a/internal/condenser/store/psm/psm_test.go
+++ b/internal/condenser/store/psm/psm_test.go
@@ -3,6 +3,7 @@ package psm
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -11,11 +12,17 @@ import (
 func TestPsmManagerStoresPodsAndReplicaSets(t *testing.T) {
 	manager := NewPsmManager(NewPsmStore(filepath.Join(t.TempDir(), "psm.json")))
 
-	require.NoError(t, manager.StorePod(StorePodRequest{PodId: "pod-1", Name: "web", Namespace: "default", UID: "uid-1", State: "created", Labels: map[string]string{"app": "web"}, Rootless: true}))
+	require.NoError(t, manager.StorePod(StorePodRequest{PodId: "pod-1", Name: "web", Namespace: "default", UID: "uid-1", State: PodStateCreated, Labels: map[string]string{"app": "web"}, Rootless: true}))
 	pod, err := manager.GetPodById("pod-1")
 	require.NoError(t, err)
 	assert.Equal(t, "web", pod.Name)
 	assert.True(t, pod.Rootless)
+
+	require.NoError(t, manager.UpdatePodOwner("pod-1", OwnerKindReplicaSet, "rs-1"))
+	pod, err = manager.GetPodById("pod-1")
+	require.NoError(t, err)
+	assert.Equal(t, OwnerKindReplicaSet, pod.OwnerKind)
+	assert.Equal(t, "rs-1", pod.OwnerId)
 
 	require.NoError(t, manager.StorePodTemplate("tpl-1", PodTemplateSpec{Name: "web", Namespace: "default", Rootless: true}))
 	require.NoError(t, manager.StoreReplicaSet("rs-1", ReplicaSetSpec{Name: "web", Namespace: "default", Replicas: 2, TemplateId: "tpl-1"}))
@@ -30,6 +37,21 @@ func TestPsmManagerStoresPodsAndReplicaSets(t *testing.T) {
 	rs, err = manager.GetReplicaSet("rs-1")
 	require.NoError(t, err)
 	assert.Equal(t, 3, rs.Spec.Replicas)
+
+	next := time.Now().Add(time.Minute).Truncate(time.Second)
+	require.NoError(t, manager.UpdateReplicaSetReconcileStatus("rs-1", 2, "create failed", next))
+	rs, err = manager.GetReplicaSet("rs-1")
+	require.NoError(t, err)
+	assert.Equal(t, 2, rs.ReconcileAttempt)
+	assert.Equal(t, "create failed", rs.LastReconcileError)
+	assert.Equal(t, next, rs.NextReconcileAt)
+
+	require.NoError(t, manager.ClearReplicaSetReconcileStatus("rs-1"))
+	rs, err = manager.GetReplicaSet("rs-1")
+	require.NoError(t, err)
+	assert.Zero(t, rs.ReconcileAttempt)
+	assert.Empty(t, rs.LastReconcileError)
+	assert.True(t, rs.NextReconcileAt.IsZero())
 
 	require.NoError(t, manager.RemoveReplicaSet("rs-1"))
 	require.NoError(t, manager.RemovePod("pod-1"))

--- a/internal/condenser/store/psm/psm_test.go
+++ b/internal/condenser/store/psm/psm_test.go
@@ -44,7 +44,7 @@ func TestPsmManagerStoresPodsAndReplicaSets(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, rs.ReconcileAttempt)
 	assert.Equal(t, "create failed", rs.LastReconcileError)
-	assert.Equal(t, next, rs.NextReconcileAt)
+	assert.True(t, next.Equal(rs.NextReconcileAt), "expected %s, got %s", next, rs.NextReconcileAt)
 
 	require.NoError(t, manager.ClearReplicaSetReconcileStatus("rs-1"))
 	rs, err = manager.GetReplicaSet("rs-1")


### PR DESCRIPTION
## Summary

This PR hardens the resource controller reconciliation path for the remaining controller stability issues:

- Adds explicit pod ownership metadata so ReplicaSets can reconcile only the pods they actually manage.
- Adds conservative legacy matching for old ReplicaSet pods that do not yet have ownership metadata.
- Treats pod infra containers as healthy only when exactly one matching infra container is running.
- Adds ReplicaSet reconcile backoff and last-error status fields to avoid noisy retry loops and expose failure state.
- Defines shared pod/container state constants to reduce string drift across controller and service code.
- Extends controller and PSM unit coverage for ownership, infra health, and reconcile backoff behavior.

## Motivation

Fixes: #51
Fixes: #53 
Fixes: #54 
Fixes: #56 
Fixes: #57 

ReplicaSet reconciliation was still relying heavily on template IDs and container-name heuristics. That can cause incorrect ownership decisions when multiple resources share templates, when stale infra containers remain, or when a controller repeatedly fails and immediately retries without preserving useful status.

The changes make ownership explicit, make infra health checks stricter, and surface reconcile failures in the resource model so the controller is safer and easier to debug.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Refactoring
- [x] Test improvement
- [ ] Build / CI / packaging
- [ ] Security hardening

## Affected areas

- [ ] CLI
- [x] Condenser API / controller
- [ ] Droplet runtime
- [x] Container lifecycle
- [ ] Container exec / exec-shim
- [ ] Rootless containers
- [ ] Image handling
- [ ] Networking / policy / netflow
- [x] Kubernetes-style resources
- [ ] Snap / packaging
- [ ] Documentation

## Security-sensitive changes

Does this PR affect any of the following?

- [x] namespaces
- [ ] mount / rootfs / pivot_root
- [ ] cgroups
- [ ] capabilities
- [ ] seccomp
- [ ] AppArmor
- [ ] rootless UID/GID mappings
- [ ] certificate / API authentication
- [ ] network namespace / iptables / nftables
- [ ] user-controlled bind mounts / host paths

If yes, explain the impact and the expected security behavior:

This PR does not change namespace creation or privilege setup. It changes controller health and ownership decisions around pod infra containers, which indirectly decide when a managed pod should be recreated. The stricter invariant is that a pod is considered healthy only when exactly one infra container is running for that pod.

## Testing

Commands run:

```sh
workshop run -- test-unit
workshop run -- test-e2e
```

Results:

- `test-unit` passed.
- `test-e2e` passed after validating image, network, policy, container, bottle, namespace, pod, ReplicaSet, Deployment, Service, and all-kind YAML apply/remove flows.

## Documentation

- [ ] Documentation updated
- [x] Documentation not needed

## Compatibility / breaking changes

- [x] No breaking changes
- [ ] Possible breaking changes described below

The PSM model gains additive fields for pod ownership and ReplicaSet reconcile status. Existing pod records without ownership metadata still use a conservative legacy fallback for single-template ReplicaSets whose pod names match the ReplicaSet-generated prefix.
